### PR TITLE
Add job-board: backend, poller, and firefox plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 # Job Search Automations
 A collection of tools to help identify jobs and apply to them.
 
+The repo holds two distinct surfaces:
+
+1. **Job Board** (`job-board/`): a runtime stack you self-host. Flask + SQLite backend, a CLI poller that walks targeted companies' ATS feeds, and a Firefox extension that scores postings as you browse. Server-side scoring against Anthropic. See [`job-board/README.md`](job-board/README.md).
+2. **GitHub Actions** (below): composite actions a separate resume-as-code repo invokes at commit time to qualify, tailor, and last-look a resume against a specific job description using Google Gemini.
+
+The two surfaces are independent. You can use either without the other.
+
+## Job Board
+
+Three components living together in [`job-board/`](job-board/):
+
+| Component | Role |
+|---|---|
+| **job-store** | Flask + SQLite backend. Inbox UI, scoring endpoint, dedupe, ranking math. |
+| **poller** | CLI that watches `company_targets` and posts new openings to job-store. |
+| **firefox-plugin** | Browser extension that scores postings via job-store and surfaces a "watch this company" button. |
+
+Both the plugin and the poller POST job descriptions to job-store without a fit score. job-store calls Anthropic with the resume and the prompt, persists the analysis, returns the score. Neither the plugin nor the poller ever sees the API key.
+
+See [`job-board/README.md`](job-board/README.md) for the architecture diagram, configuration, and local-run instructions.
+
 ## GitHub Actions
 ### dev-dull/job-search-automations/gemini-qualified
 Uses the free tier of Google Gemini to compare a resume to a job description and ranks if the position is a good fit with a score between 1 and 100.

--- a/job-board/README.md
+++ b/job-board/README.md
@@ -1,0 +1,88 @@
+# Job Board
+
+Three components that work in unison to discover, score, and triage job postings:
+
+| Component | Role | Path |
+|---|---|---|
+| **job-store** | Flask + SQLite backend. Inbox UI, scoring endpoint, dedupe, company-targets CRUD, ranking math. Single source of truth for the resume, the prompt, the schema, and the Anthropic API key. | `job-store/` |
+| **poller** | CLI that walks the `company_targets` table, fetches current openings from each ATS, dedupes, applies title and location filters, and POSTs survivors to `job-store/jobs/score` for scoring. Lives inside `job-store/` because it shares Python imports with the backend. | `job-store/poller.py` |
+| **firefox-plugin** | Browser extension. Extracts the JD from whatever page you're on, POSTs it to job-store, renders the score. Also surfaces a "watch this company" button when the page is on a supported ATS. | `firefox-plugin/` |
+
+## How they talk
+
+```
+                   browser tab on a job posting
+                              |
+                              v
+              +---------------------------+
+              |     firefox-plugin        |
+              |  (extract JD + POST)      |
+              +-------------+-------------+
+                            |
+                            | POST /jobs/score
+                            |  (no fit_score in the body)
+                            v
+   +-----------+    HTTP    +---------------------------+    HTTP    +-----------+
+   |  poller   |----------->|         job-store         |<-----------|  browser  |
+   |  (CLI)    |  POST /    |  Flask + SQLite           |    GET /   |  (inbox)  |
+   +-----------+  jobs/score|  Inbox UI at /            |            +-----------+
+                            |  Companies CRUD at /companies         
+                            +-------------+-------------+           
+                                          |
+                                          | Anthropic API (server-side
+                                          |  scoring; resume + prompt
+                                          |  live in job-store, not in
+                                          |  the plugin or the poller)
+                                          v
+                                  api.anthropic.com
+```
+
+Both the plugin and the poller POST job descriptions without a `fit_score`. job-store calls Anthropic, persists the analysis, and returns the score. Neither the plugin nor the poller ever sees the API key.
+
+## Configuration
+
+job-store reads these env vars:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | yes | server-side scoring |
+| `RESUME_PATH` | yes | absolute path to the resume YAML (e.g. `~/wip/resume/resume_details.yaml`) |
+| `ANTHROPIC_MODEL` | no | defaults to `claude-haiku-4-5` |
+| `GROWTH_KEYWORDS` | no | comma-separated phrases the scorer rewards (career-growth signal) |
+
+The poller has no env-var requirements of its own; it talks to job-store over HTTP.
+
+The plugin's only configuration is the backend URL (set in the options page). It defaults to `http://127.0.0.1:5000`.
+
+## Running locally
+
+```bash
+cd job-board/job-store
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+export ANTHROPIC_API_KEY=sk-ant-...
+export RESUME_PATH=~/wip/resume/resume_details.yaml
+flask --app app run --port 5000
+```
+
+In another terminal:
+
+```bash
+cd job-board/job-store
+.venv/bin/python poller.py --dry-run        # preview
+.venv/bin/python poller.py                  # live run
+```
+
+For the plugin: open `about:debugging` in Firefox, load `job-board/firefox-plugin/manifest.json` as a temporary add-on, then point its backend URL at `http://127.0.0.1:5000` on the options page.
+
+## Component-specific docs
+
+- **job-store** internals and routes: [`job-store/README.md`](job-store/README.md)
+- **firefox-plugin** install and dev notes: [`firefox-plugin/README.md`](firefox-plugin/README.md)
+- **Architecture history** and the rationale for the three-component split: [`docs/automation-plan.md`](docs/automation-plan.md)
+- **Server-side scoring** design (why scoring lives in job-store, not in the plugin or the poller): [`docs/server-side-scoring.md`](docs/server-side-scoring.md)
+- **iCIMS adapter** notes and deferred-decision context: [`docs/icims-adapter-notes.md`](docs/icims-adapter-notes.md)
+
+## Companion: GitHub Actions
+
+This repo also hosts a collection of composite GitHub Actions used by a separate resume-as-code repo for tailoring and scoring at commit time. See the top-level `README.md` for those: `gemini-qualified`, `gemini-tailor`, `gemini-pick-best-fit`, `gemini-cover-outline`, `gemini-last-looks`, `render-resume`.

--- a/job-board/docs/automation-plan.md
+++ b/job-board/docs/automation-plan.md
@@ -1,0 +1,184 @@
+# Job-search automation plan
+
+## Goal
+
+Replace the manual "find a job → cut a branch → run the pipeline" loop with an automated discovery, scoring, and ranking system that surfaces the highest-fit, highest-likelihood-of-callback positions first. Once the user picks a position to apply to, hand off to the existing branch-per-job CI/CD pipeline (`process-resume.yaml` et al.) unchanged.
+
+## Architecture
+
+```
+[ discovery: 3 producers ]
+        │
+        ▼
+   [ shared store ] ──► [ analysis worker ] ──► [ ranker ] ──► [ local webpage ]
+                                                                     │
+                                                          (user clicks "apply")
+                                                                     ▼
+                                                       [ existing resume-repo CI/CD ]
+                                                                     │
+                                                          (callback / ghost / offer)
+                                                                     ▼
+                                                          [ outcome tracking ] ──┐
+                                                                                  │
+                                                          feeds platform_factor ◄┘
+```
+
+## Discovery methods
+
+Three independent producers writing to the same shared store. Each gets its own planning session and document — only the interface matters here.
+
+1. **Targeted-company poller** — given a configurable list of careers-page URLs, polls on a schedule.
+2. **Browser plugin** — recognizes job-search sites and captures listings as the user browses.
+3. **Autonomous crawler** — long-running agent that walks job boards / new company career pages on a schedule.
+
+All three emit the same record shape (see schema). Suggested build order: poller → plugin → crawler. Poller is the smallest viable producer and validates the shared pipeline end-to-end before more complex producers exist.
+
+## Shared pipeline
+
+### Store
+
+**Decision:** Relational DB, not a queue. Start with SQLite; migrate to Postgres only if multiple writers or remote access become a real need.
+
+Rationale: jobs move through stages and we need dedupe-by-URL, querying for ranking, and stage-transition updates — a queue alone can't do that. The `status` column drives the state machine; workers `SELECT … WHERE status = ? ORDER BY discovered_at LIMIT 1` to pull next work.
+
+**`jobs` table:**
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| url | text UNIQUE | dedupe key across all 3 producers |
+| company | text | |
+| title | text | |
+| description | text | full JD body |
+| ats_platform | text | greenhouse, ashby, workday, lever, icims, … |
+| posted_at | date | drives age-decay in ranking |
+| discovered_at | timestamp | |
+| discovered_by | text | poller / plugin / crawler |
+| status | text | discovered, analyzing, ranked, applied, closed |
+| fit_score | real NULL | 0–100, set by analysis step |
+| analysis_json | text NULL | full structured output (fit, strengths, weaknesses, company impressions) |
+| rank_score | real NULL | computed ranking score; recomputed on read or on schedule |
+| applied_at | timestamp NULL | |
+| branch | text NULL | resume-repo branch name once applied |
+
+**`outcomes` table** (1:1 with `jobs` once applied; mirrors current CSV columns):
+
+| column | type | notes |
+|---|---|---|
+| job_id | int FK → jobs.id | |
+| referral | bool | did the application include a referral |
+| callback | bool | |
+| callback_at | date NULL | |
+| ghosted | bool | default flips true after N days with no contact (configurable) |
+| offer | bool | |
+| notes | text | |
+
+This replaces the CSV outright once outcome tracking is in place.
+
+### Analysis worker
+
+Pulls `status='discovered'` rows, runs analysis, writes `fit_score` + `analysis_json`, advances to `status='ranked'`. Output shape mirrors the existing `gemini-qualified` action so the rest of the pipeline doesn't care which model produced it.
+
+**Path differs by producer.** The two-stage local-prefilter design originally drafted here was hedging against the autonomous crawler's potentially high volume. At browser-plugin volume (intrinsically bounded by what the user looks at, ~50/day) the math doesn't justify local infra. Settled positions:
+
+| Producer | Model path |
+|---|---|
+| Browser plugin (`firefox-plugin/`) | **Anthropic API + Claude Haiku 4.5**, prompt-cached resume. ~$5–12/month at expected volume. Already shipped; no local infra needed. |
+| Targeted-company poller | Same as plugin to start (shared analysis worker); revisit if volume turns out large. |
+| Autonomous crawler | **Two-stage** — local Gemma (pre-filter, on homelab RTX 2080 once available) + Anthropic API for the survivors. This is where the local-inference investment actually pays back. |
+
+**Interim hosting (until homelab GPU is ready):** Anthropic API only, no local Gemma. The crawler isn't built yet anyway, so this isn't a stopgap for anything in production — just the default for the plugin and poller paths.
+
+**Why Anthropic over Gemini for the new pipeline:** consolidates with everyday Claude Code usage (one vendor, one key, one SDK pattern), and the existing CI/CD's Gemini integration is unchanged — that's the *applicant-facing* tooling (tailor, cover-letter, last-looks) which is a different concern. Decoupling the discovery analyzer from the application tooling is a feature: the two pipelines can evolve independently.
+
+**Open items still worth measuring:**
+
+- Bake-off across producers: once the autonomous crawler exists, run 5–10 historical CSV rows through Haiku-only vs. Gemma-prefilter+Haiku and compare cost-per-correct-ranking before locking the crawler's analysis path.
+- Confirm Gemma generation when starting the crawler subproject — the homelab work targets whatever's current at build time.
+
+### Ranking
+
+`rank_score` is the primary sort key in the UI. Recomputed daily so age-decay actually moves things over time.
+
+**Skeleton formula** (weights to tune against real data):
+
+```
+rank_score = fit_score * age_decay(posted_at) * platform_factor(ats_platform)
+
+age_decay(d):
+  days = today - d
+  return clamp(1.0 - days / 45, 0.3, 1.0)
+  # rationale: 45-day half-life-ish; postings older than that
+  # likely have a candidate further in the pipeline already.
+  # 0.3 floor keeps stale jobs visible rather than dropping them.
+
+platform_factor(p):
+  global_rate    = total_callbacks / total_applied
+  # Bayesian smoothing for platforms with low n
+  platform_rate  = (platform_callbacks + 2) / (platform_applied + 10)
+  return clamp(0.5 + (platform_rate / global_rate) * 0.5, 0.5, 1.5)
+  # rationale: platform swings rank up to ±50% but can't dominate fit score.
+```
+
+**Open tuning items** — fix once we have ≥30 outcomes in the new system:
+
+- 45-day decay constant.
+- 0.3 age floor.
+- Bayesian prior strength `(+2, +10)`.
+- Whether to add a referral multiplier when we already know the company has a referral path open.
+
+### UI
+
+**Decision:** local-only webpage, served by the same process that holds the SQLite handle. Single-user, never exposed publicly.
+
+Rationale:
+- Ranked-list-with-drill-down is the right shape for browse + triage; CLI is too lossy, Slack/email-style notifications are wrong for this volume.
+- Local-only because a public list of currently-targeted companies is information leakage about an in-progress job hunt.
+
+Stack: Flask + a single HTML page with a sortable table, status filters, and click-through to the listing URL. The `apply` button on a row is what fires the handoff to the resume CI/CD.
+
+### Hosting
+
+| component | host | rationale |
+|---|---|---|
+| SQLite DB + Flask UI | homelab | always-on, persistent, single-user, no cost |
+| Local Gemma inference (pre-filter) | homelab GPU (RTX 2080) | zero marginal cost |
+| Frontier API calls (analysis) | from the homelab worker | no infra, just an API key |
+| Targeted-company poller | homelab cron | low CPU, scheduled, can tolerate restarts |
+| Autonomous crawler | DigitalOcean droplet | residential homelab IPs may get flagged by job boards; rotate from a clean cloud IP |
+| Browser plugin | local (browser) | by definition |
+
+AWS credits stay in reserve — burst analysis if backlog grows, or fail-over hosting if the homelab is down. No day-to-day AWS dependency.
+
+## Application handoff
+
+When the user clicks "apply" in the UI:
+
+1. UI POSTs to a backend endpoint with the `job.id`.
+2. Backend creates branch `companyName-jobID-YYYYMMDD` (matches existing convention) in the resume repo, scaffolds `job.txt` from the stored description, and `company.txt` if analysis captured careers-page text.
+3. Push the branch. `process-resume.yaml` triggers the existing `score-resume` flow.
+4. Update the DB row: `status='applied'`, `applied_at=now()`, `branch=…`.
+5. From there, the user iterates manually using the existing CI/CD just like today — this plan does not change any of that.
+
+## Outcome tracking
+
+Currently the CSV is updated by hand. In the new system:
+
+- "Mark callback / ghost / offer" buttons on each row in the UI write to `outcomes`.
+- A nightly job auto-flips `ghosted=true` for applied rows older than N days with no callback (configurable; start at 30).
+- `platform_factor` recomputes from `outcomes` on a schedule, so as platform success rates shift the ranking adapts.
+- One-time import: load the existing CSV into `jobs` + `outcomes` so the platform stats start with real data, not zero.
+
+## Research items (do these before kicking off subprojects)
+
+1. **Model bake-off** — Anthropic vs Gemini vs local-prefilter+frontier. Score 5–10 historical CSV rows with each, compare ranking against actual callback/offer outcomes. Blocks the analysis subproject.
+2. **Gemma sizing** — confirm 4B int4 fits and runs at acceptable latency on the 1660 Super (so the 2080 stays free for anything that needs more VRAM). Blocks the pre-filter design.
+3. **Volume estimate** — how many listings/week will the three producers actually emit? Drives whether the pre-filter is needed at all, and whether SQLite is sufficient long-term.
+
+## Subproject planning sessions
+
+Each gets its own document and a separate planning session. Build the shared pipeline alongside the first subproject so it has a real consumer from day one.
+
+- `firefox-plugin/` — **shipped 2026-05-03** as standalone analyzer (no backend yet); see `firefox-plugin/README.md`. Inverted from the originally-planned ordering because the plugin works as a useful manual tool even without the storage backend, so it ships value immediately.
+- `AUTOMATION_PLAN_targeted_poller.md` — next; simplest producer, validates the shared pipeline end-to-end. Will be the first consumer of the SQLite store once it's stood up.
+- `AUTOMATION_PLAN_autonomous_crawler.md` — last; depends on rest being stable, has the most failure modes (rate limits, bot detection, schema drift). This is where the local Gemma pre-filter lands.

--- a/job-board/docs/icims-adapter-notes.md
+++ b/job-board/docs/icims-adapter-notes.md
@@ -1,0 +1,70 @@
+# iCIMS adapter: investigation notes
+
+**Date**: 2026-06-04
+**Status**: Deferred. No iCIMS adapter exists in `job-store/adapters/`.
+
+## Context
+
+User flagged that the Rivian careers page (`https://careers.rivian.com/careers-home/jobs`) doesn't register on the plugin for watching via the poller. Investigation traced the page to iCIMS as the backing ATS.
+
+The plugin's `deriveCareersUrl()` in `firefox-plugin/lib.js` only recognizes hostnames for Greenhouse, Ashby, Lever, and Workday (the four ATSes with poller adapters). iCIMS pages render no watch bar, and the `/companies` create endpoint would reject the URL as unsupported.
+
+## What's behind Rivian's careers page
+
+- Customer-facing surface: `careers.rivian.com/careers-home/jobs`
+- Underlying iCIMS tenant: `careers-rivian.icims.com` (redirects to `us-careers-rivian.icims.com`)
+- iCIMS subdomain pattern observed in many other tenants: `careers-<slug>.icims.com` or `<slug>.icims.com/jobs/search`
+
+Confirmed by:
+- iCIMS markers in the main HTML body (`icims.com/jobs/login`, "iCIMS System ID")
+- iCIMS-platform JS bundles loaded from `cdn02.icims.com`
+- A direct fetch of `https://careers-rivian.icims.com/jobs/search?ss=1` redirects to `us-careers-rivian.icims.com/jobs/search?ss=1`
+
+## Why iCIMS is the hardest of the major ATSes to support
+
+| Aspect | Greenhouse | Ashby | Lever | Workday | iCIMS |
+|---|---|---|---|---|---|
+| Public JSON API | Yes (`boards-api.greenhouse.io`) | Yes (`api.ashbyhq.com/posting-api`) | Yes (`api.lever.co/v0/postings`) | Yes (CXS POST API) | No |
+| Auth required for list | No | No | No | No | Effectively yes (bot-checks) |
+| HTML-only fallback works | N/A (API is clean) | N/A | N/A | N/A | No (JS-rendered) |
+| Cloudflare-style guard | No | No | No | No | Yes |
+| Multi-page pagination | No (single response) | No | No | Yes (per `MAX_PAGES`) | Yes |
+
+Three specific iCIMS blockers we observed:
+1. The plain-HTML fetch of `careers-rivian.icims.com/jobs/search?ss=1&in_iframe=1` returns 143 bytes (a redirect / bot-check shell). The actual job listings only materialize after iCIMS's platform JS runs in a browser.
+2. No documented public JSON endpoint for the job list. Some tenants leak data via guessable URLs but the pattern varies per customer and breaks when iCIMS updates their platform.
+3. Listings include JSON-LD `JobPosting` schema markup, but only after JS render (same blocker as above).
+
+## Options considered
+
+1. **Headless browser harness** (Playwright / Puppeteer). Would JS-render the iCIMS page and scrape the resulting DOM. Heavy dependency. Slow per-poll. Brittle to iCIMS UI changes. Not consistent with the lightweight `urllib`-only adapter pattern used today.
+2. **3rd-party aggregator** (Adzuna or similar). Outsources the iCIMS scraping. Adds vendor dependency, often per-region rate limits, costs money beyond a free tier, drift in data freshness.
+3. **Tenant-specific scrape.** Probe each iCIMS customer for an undocumented endpoint that returns JSON. May work for some tenants today, may break on the next iCIMS platform release. Best-case: 30 minutes per tenant; worst-case: doesn't work at all.
+4. **Skip iCIMS in the poller.** Use the plugin only for individual iCIMS-hosted job pages (the plugin already recognizes `icims.com` in `ATS_HOSTS` for content extraction, so per-page scoring works fine). Forgo the periodic auto-poll behavior for any iCIMS-backed company.
+
+## Current decision
+
+Defer until there's a real driver (e.g., a high-fit iCIMS-hosted role you want to track over time, or several iCIMS customers piling up in the inbox). The 22 iCIMS rows already in the DB from earlier plugin browsing skew low-fit, which weakens the ROI argument.
+
+Manual fallback that works today: bookmark `careers.rivian.com/careers-home/jobs`, visit periodically, score interesting roles via the plugin.
+
+## What would reverse the decision
+
+- Multiple iCIMS-hosted companies become top-of-funnel targets.
+- A high-fit iCIMS role surfaces and the user wants ongoing visibility (vs. a one-shot application).
+- iCIMS publishes (or someone reverse-engineers cleanly) a stable JSON endpoint pattern.
+
+## If we revisit, start by
+
+1. Trying the tenant-specific scrape (option 3) against `careers-rivian.icims.com` first. Inspect dev-tools network panel for the actual XHR that populates the listing.
+2. If that pattern holds across several tenants, write `job-store/adapters/icims.py` that accepts `{tenant: "<slug>"}` in the identifier dict.
+3. Update `deriveCareersUrl()` in `firefox-plugin/lib.js` to recognize `*.icims.com` and customer-domain wrappers (`careers.<company>.com/careers-home/jobs` is one pattern; not the only one).
+4. Update `detect_ats()` in `app.py` to detect iCIMS host patterns.
+5. Update `probe_embedded_ats()` in `app.py` so the auto-resolve path can recover when a user pastes a customer-domain URL that wraps iCIMS.
+
+## Related files (current state, no iCIMS code yet)
+
+- `job-store/adapters/__init__.py`: `ADAPTERS` dispatch dict (Greenhouse, Ashby, Lever, Workday)
+- `job-store/adapters/{greenhouse,ashby,lever,workday}.py`: existing reference implementations
+- `job-store/app.py`: `ATS_DETECTORS` and `probe_embedded_ats()`
+- `firefox-plugin/lib.js`: `deriveCareersUrl()` and `JOB_SPECIFIER_PARAMS`

--- a/job-board/docs/server-side-scoring.md
+++ b/job-board/docs/server-side-scoring.md
@@ -1,0 +1,296 @@
+# Server-Side Scoring — Design Document
+
+**Status:** Proposed. No code written yet.
+**Author:** Alastair Drong + Claude
+**Date:** 2026-05-19
+
+## Goal
+
+Move the Anthropic-based fit-scoring call out of the Firefox extension and into
+the `job-store` backend. The plugin becomes a thin client (extract, POST, render);
+the backend owns the resume, the API key, the prompt, and the schema.
+
+This makes the Firefox plugin, the future discovery bot, and any other future
+consumer share one source of truth for "how does this candidate fit this role?"
+
+## Current state (problems this addresses)
+
+| Concern | Today | After |
+|---|---|---|
+| Anthropic API key location | `browser.storage.local` (one per browser, set via plugin options page) | Backend env var, set once |
+| Resume content of record | `browser.storage.local` cached copy, manually re-loaded via the plugin's "Load now" button | `resume_details.yaml` on disk, read by backend at scoring time |
+| Prompt / schema definitions | Hard-coded in `popup.js` (the plugin) | One Python module in `job-store/` |
+| Re-scoring an existing job | Re-visit the URL in Firefox; the plugin always re-scores | A backend endpoint can re-score any saved job |
+| Discovery bot scoring | Would have to duplicate the scoring logic in `job-bot/` | Discovery bot just POSTs and reads the response |
+| Manual paste | Plugin-only | Available via the inbox UI as well, optionally |
+| Cost tracking | Implicit (you see usage in the popup) | Backend can log per-call usage to SQLite for spend analysis |
+
+The plugin's *extraction* logic (LinkedIn anchor, Greenhouse-embed API fallback,
+ATS-host detection, etc.) stays in the plugin. The plugin still owns "what is the
+JD on this page" — that's a browser-side problem.
+
+## Proposed architecture
+
+```
+   ┌──────────────────────┐                  ┌──────────────────────────────┐
+   │  Firefox plugin      │                  │  job-store (Flask, local)    │
+   │                      │  POST /jobs/score│                              │
+   │  extract JD ────────►├─────────────────►│  • read resume_details.yaml  │
+   │                      │  { url, title,   │  • call Anthropic Haiku 4.5  │
+   │  render result ◄─────┤    description,  │  • upsert row in SQLite      │
+   │                      │    ats_platform }│  • return score + analysis   │
+   └──────────────────────┘                  │                              │
+                                             │  also:                       │
+   ┌──────────────────────┐                  │  GET /jobs/<id>/rescore      │
+   │  discovery bot       │  POST /jobs/score│  GET /resume                 │
+   │                      ├─────────────────►│  GET /companies/<id>/...     │
+   │  iterate companies   │  (one per role)  │                              │
+   └──────────────────────┘                  └──────────────────────────────┘
+```
+
+The plugin no longer needs:
+- The Anthropic API key
+- The resume content
+- The `FIT_SCHEMA`, `SYSTEM_INSTRUCTIONS`
+- The `MODEL` constant
+- The `scoreJob()` function
+
+The plugin still needs:
+- The `extractInPage` logic (LinkedIn anchor, Greenhouse API fallback, longest-text fallback)
+- The `detectAts` logic
+- The popup UI
+- The backend URL (already in `browser.storage.local`)
+
+## API surface (additions and modifications to `job-store`)
+
+### `POST /jobs/score` — modified
+
+**Current** payload (the plugin already computes the score client-side):
+```json
+{
+  "url": "https://...",
+  "company": "Optional",
+  "title": "Optional",
+  "description": "string",
+  "ats_platform": "greenhouse|lever|ashby|workday|linkedin|other",
+  "discovered_by": "plugin",
+  "fit_score": 82,
+  "analysis": { "summary": "...", "strengths": [...], "gaps": [...], "recommendation": "..." }
+}
+```
+
+**New** payload (plugin sends the JD, backend scores it):
+```json
+{
+  "url": "https://...",
+  "title": "Optional",
+  "description": "string",
+  "ats_platform": "greenhouse|lever|ashby|workday|linkedin|other",
+  "discovered_by": "plugin"
+}
+```
+
+**New** response:
+```json
+{
+  "id": 123,
+  "rank_score": 80,
+  "status": "ranked",
+  "fit_score": 82,
+  "company": "Voxel51",
+  "analysis": {
+    "summary": "...",
+    "strengths": [...],
+    "gaps": [...],
+    "recommendation": "strong_match|consider|weak_match|skip"
+  },
+  "usage": {
+    "input_tokens": 3803,
+    "cache_read_input_tokens": 7719,
+    "cache_creation_input_tokens": 0,
+    "output_tokens": 108,
+    "cost_usd": 0.0089
+  }
+}
+```
+
+**Backwards compatibility:** if the request includes `fit_score` and `analysis`,
+backend skips its own Anthropic call and just persists what was sent. This lets
+the plugin be migrated incrementally — old plugin builds still work.
+
+### `GET /resume` — new
+
+Reads `resume_details.yaml` from a configured path. Returns plain text. Used by
+the plugin to "refresh resume now" or to bootstrap a new plugin install.
+
+```json
+{
+  "content": "<full YAML content>",
+  "path": "/path/to/resume_details.yaml",
+  "mtime": "2026-05-19T14:21:00Z",
+  "sha256": "..."
+}
+```
+
+### `POST /jobs/<id>/rescore` — new
+
+Re-runs scoring against the stored `description`. Optional payload:
+
+```json
+{ "force": true }  // skip the "already scored recently" guard
+```
+
+Use case: after a resume change, re-score the top N jobs to see whether the
+new resume framing moves any borderline scores into the "strong_match" zone.
+
+### `POST /companies/<id>/rebuild-deny-list` — already designed in chunk 2
+
+No change. Reads role titles from the company's ATS API, calls Anthropic, writes
+the new deny list. Uses the same Anthropic client as scoring.
+
+## Anthropic client module (`job-store/anthropic_client.py`)
+
+One module owns:
+- API key loading (`os.environ["ANTHROPIC_API_KEY"]`)
+- Resume loading + caching (read `resume_details.yaml`, watch mtime, refresh)
+- The `score_job(description, url, title, ats_platform)` function
+- The `generate_deny_list(role_titles)` function
+- The `MODEL = "claude-haiku-4-5"` constant + the `FIT_SCHEMA`
+
+Pseudocode:
+
+```python
+def score_job(*, description, url, title, ats_platform):
+    resume = _get_resume_cached()
+    response = client.messages.create(
+        model="claude-haiku-4-5",
+        max_tokens=2048,
+        system=[
+            {"type": "text", "text": SYSTEM_INSTRUCTIONS},
+            {"type": "text", "text": f"<resume>\n{resume}\n</resume>",
+             "cache_control": {"type": "ephemeral"}},
+        ],
+        messages=[{"role": "user", "content": _format_job_prompt(...)}],
+        output_config={"format": {"type": "json_schema", "schema": FIT_SCHEMA}},
+    )
+    return _parse_fit_response(response)
+```
+
+Prompt caching keeps per-scoring cost at ~$0.01 across many jobs.
+
+## Plugin changes (`firefox-plugin/popup.js`)
+
+Delete:
+- `FIT_SCHEMA`, `SYSTEM_INSTRUCTIONS`, `MODEL`, `API_URL`, `MAX_DESCRIPTION_CHARS`
+- `scoreJob()` function
+- Options page fields for API key and resume content
+- `browser.storage.local` reads/writes for `apiKey`, `resume`, `resumeFilePath`
+
+Add (or keep):
+- `extractInPage`, `extractCurrentTab`, `detectAts` — unchanged
+- `sendToBackend` — renamed to `scoreViaBackend`, returns the full analysis
+- `renderResult` — unchanged structurally, just receives the response from the
+  backend instead of computing locally
+
+Net result: the plugin becomes about half its current size and has zero external
+dependencies beyond the local backend.
+
+## Migration phases
+
+**Phase 0 — Today:** plugin does scoring; backend just persists.
+
+**Phase 1 — Add `/resume` endpoint and the new `/jobs/score` server-side path.**
+Backend can score on its own; plugin keeps doing client-side scoring. New
+endpoint is dormant for the plugin but ready for the discovery bot.
+
+**Phase 2 — Discovery bot uses server-side scoring.** Bot POSTs raw JDs to
+`/jobs/score` without `fit_score`/`analysis`; backend handles scoring. This
+proves the path works at modest volume.
+
+**Phase 3 — Plugin migrates.** Plugin stops calling Anthropic directly. Submits
+raw JD to `/jobs/score`. Renders the response. Old behavior preserved as
+fallback if backend is unreachable.
+
+**Phase 4 — Cleanup.** Plugin options page loses the API-key + resume fields.
+The plugin only needs the backend URL.
+
+Each phase is independently shippable.
+
+## Failure modes and fallbacks
+
+| Scenario | Today | After |
+|---|---|---|
+| Backend unreachable | Plugin still scores (Anthropic direct), can't save | Plugin scores via cached client-side fallback only if user has chosen to keep one; otherwise shows "backend offline, no score" |
+| Anthropic API down | Plugin fails | Backend fails; plugin shows "scoring unavailable" |
+| Stale resume | Plugin's `browser.storage.local` copy can drift from disk | Backend reads `resume_details.yaml` per call (cheap), so always fresh |
+| API key rotated | User opens plugin options, pastes new key | User updates one env var, restarts `flask` |
+| Cost runaway | Plugin doesn't track | Backend logs every call's `usage` to SQLite; easy to query |
+
+**Recommended fallback policy:** the plugin keeps the option (off by default)
+to fall back to a client-side Anthropic call if the backend doesn't respond
+within ~5 seconds. This is only useful if the user wants to score on the road
+without their job-store running. Most days the fallback is unused; on the few
+days it matters (laptop offline, on a plane, etc.) it salvages the workflow.
+
+## Open questions
+
+1. **Should the plugin display Gemini's deep analysis when available?** The Gemini
+   workflow produces 4 scores; the plugin only shows one. Could add a "deeper
+   analysis available — view in inbox" affordance once a branch has been pushed.
+   Out of scope for this proposal but worth considering later.
+
+2. **One model, or both at the backend?** This proposal centralizes on Haiku 4.5
+   (the plugin's current model). The Gemini workflow stays separate (different
+   prompt structure, different purpose: deep analysis after creating a branch).
+   Long-term, could converge on one — but that's a separate design.
+
+3. **Resume hot-reload vs explicit reload?** Cheapest: re-read `resume_details.yaml`
+   on every scoring call. The file is small (~20KB) and reads are local.
+   Alternative: cache + watch mtime. Recommendation: start with re-read-per-call;
+   optimize only if profiling shows it matters.
+
+4. **Where does the bot fit?** The bot becomes the discovery driver:
+   for each configured company, fetch role titles → filter against deny list →
+   for each surviving role, POST description to `/jobs/score`. No bot-side
+   Anthropic client. The bot is purely "iterate and dispatch."
+
+## Non-goals
+
+- Replacing the Gemini deep-analysis workflow. It runs after creating an
+  application branch, produces a different shape of analysis, and stays as-is.
+- Building a web UI for editing the resume. Resume edits still happen via
+  `git` and `resume_details.yaml`.
+- Multi-user support. This is a single-user tool.
+- Authentication on the backend. It's bound to `127.0.0.1` and remains so.
+
+## Tradeoffs accepted
+
+- Plugin gains a hard dependency on the local backend running. Without it, the
+  plugin shows "backend offline." (Mitigated by the optional client-side
+  fallback.)
+- The backend now needs an Anthropic API key. One more secret to manage.
+- Latency for scoring goes up slightly: extract → HTTP POST → backend Anthropic
+  call → response. The HTTP hop is local, so ~10-20ms overhead per call.
+
+## Cost analysis
+
+No change. Same model, same prompt structure, same prompt caching. The Anthropic
+call moves from browser to backend; the wire-cost is identical. The backend
+adds ~20ms latency and gains the ability to log per-call usage for spend
+tracking, which the plugin can't currently do.
+
+## Concrete next step (if/when this is greenlit)
+
+Smallest meaningful piece:
+
+1. Add `GET /resume` endpoint to `job-store/app.py` (reads `resume_details.yaml`,
+   returns the content + mtime). ~20 lines.
+2. Add `anthropic_client.py` module with `score_job()` that mirrors `popup.js`'s
+   current `scoreJob()` exactly. ~80 lines.
+3. Extend `POST /jobs/score` to call `score_job()` when no `fit_score` is
+   provided. ~10 lines.
+4. Test by POSTing a JD to the backend (via curl) without a fit_score and
+   verifying the response shape matches what the plugin expects.
+
+That's it for Phase 1. Discovery bot consumption (Phase 2) and plugin migration
+(Phase 3) come later.

--- a/job-board/firefox-plugin/README.md
+++ b/job-board/firefox-plugin/README.md
@@ -1,0 +1,61 @@
+# firefox-plugin
+
+Firefox MV3 extension. Thin client to the `job-store` backend: extract the job description from whatever page you're on, POST it to the backend, render the score that comes back. Also surfaces a "watch this company" button when the page is on a supported ATS so you can add it to the poller's company_targets in one click.
+
+The plugin holds no API key, no resume, and no scoring prompt. Server-side scoring lives in job-store; see [`../docs/server-side-scoring.md`](../docs/server-side-scoring.md) for the rationale.
+
+## What it does
+
+- Recognizes job postings on Greenhouse, Ashby, Lever, Workday, LinkedIn, iCIMS, BambooHR, Workable, Gem, Rippling, and IBM Careers.
+- Extracts the JD via in-page DOM selectors (tier-1 ATS-specific, tier-2 generic), with fallbacks to canonical APIs (Greenhouse `boards-api` and Ashby `posting-api`) when the in-page DOM is JS-rendered.
+- POSTs the JD to `job-store/jobs/score` (no `fit_score` in the body so the backend scores it). Renders the structured response.
+- Local cache of recent scores so re-opening on the same URL renders instantly without round-tripping the backend.
+- Toolbar badge shows the score number for any page you've already scored. On a cache miss, the background script asks the backend whether it has a score for this URL.
+- "Watch this company" button POSTs to `/companies` to add the page's company to the poller's targets, when the page is on a supported ATS.
+- Recognizes its own backend URL and shows a friendly "you're on the inbox" state instead of trying to score the inbox itself.
+
+## Architecture
+
+- **`manifest.json`** Manifest V3. `host_permissions` for the supported ATS hosts plus localhost (for the default backend URL). `optional_host_permissions: ["*://*/*"]` so the user can grant access to a hosted backend URL at runtime.
+- **`background.js`** Sets the briefcase emoji icon via OffscreenCanvas. Listens to `tabs.onActivated`, `tabs.onUpdated`, and `browser.storage.onChanged` for `scoreCache` to keep the toolbar badge in sync per tab.
+- **`lib.js`** Loaded into both popup and background. Holds the score cache, the URL canonicalizer (`linkedin:<id>` / `gh:<id>` / `ashby:<id>` collapse forms), the careers-index URL detector, and the backend-lookup fallback.
+- **`popup.html` / `popup.js` / `popup.css`** The action popup. Handles the extract → POST → render flow, the cache notice, the watch bar, the Re-score button, the manual-paste fallback, and the "this is your job-store inbox" state.
+- **`options.html` / `options.js` / `options.css`** Settings page. Only setting is the backend URL. Localhost works out of the box; any other host triggers a one-time Firefox permission prompt the first time you click Save or Test.
+
+## Install (development)
+
+1. Open `about:debugging#/runtime/this-firefox` in Firefox.
+2. Click **Load Temporary Add-on…**.
+3. Pick `manifest.json` from this directory.
+4. The options page opens on first install. Set the backend URL to `http://127.0.0.1:5000` (the job-store default).
+5. Click Test. If the backend's reachable you'll see "Reachable. Currently N open jobs in inbox."
+6. Click Save.
+7. Visit a job posting on any supported ATS and click the briefcase icon in the toolbar.
+
+Temporary add-ons are unloaded when Firefox restarts; re-pick the manifest each session. For a persistent install you'd need to sign with AMO; that's not covered here.
+
+## Pointing at a hosted backend
+
+When you move job-store off `127.0.0.1`, change the backend URL in the options page. The first time you click Save (or Test) on a non-localhost URL, Firefox prompts to grant the extension access to that host. Accept it. The plugin retries the test automatically.
+
+To revoke later: `about:addons` → Job Fit Scorer → Permissions → uncheck the host.
+
+## Local cache
+
+The plugin stores the most recent ~200 scoring results in `browser.storage.local` under `scoreCache`, keyed by the canonical posting id (`gh:N`, `ashby:N`, `linkedin:N`, or a normalized URL for non-canonicalizable pages). On a cache hit, the popup renders instantly and the toolbar badge picks up the score number; on a cache miss, the background script asks the backend via `GET /jobs/score?url=<encoded>` and populates the cache from there.
+
+The Re-score button bypasses both caches and forces a fresh `force: true` POST to the backend.
+
+## Manual paste
+
+If the JD can't be extracted from the page (JS-heavy ATS that doesn't expose a useful API, paywalled content, etc.), the popup shows a "no job posting detected" state with a textarea. Paste the JD and click "Score this." Manual paste skips the local cache (since there's no stable URL key) but still POSTs to the backend so the row lands in the inbox.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `manifest.json` | MV3 manifest, permissions, optional host permissions for non-localhost backends |
+| `background.js` | Toolbar badge updater, briefcase icon paint, options-page-on-install |
+| `lib.js` | Shared helpers: URL canonicalization, cache, careers-index detection, badge paint |
+| `popup.html` / `popup.js` / `popup.css` | Action popup: extract, render, watch bar, manual paste |
+| `options.html` / `options.js` / `options.css` | Settings: backend URL with permission grant |

--- a/job-board/firefox-plugin/background.js
+++ b/job-board/firefox-plugin/background.js
@@ -1,0 +1,115 @@
+"use strict";
+
+// Open the options page the first time the extension is installed so the user
+// is prompted to paste an API key + resume.
+browser.runtime.onInstalled.addListener(({ reason }) => {
+  if (reason === "install") {
+    browser.runtime.openOptionsPage();
+  }
+});
+
+// Toolbar icon: render the briefcase emoji into an OffscreenCanvas so the
+// extension's action button shows 💼 instead of a placeholder puzzle piece.
+// Done at runtime (rather than shipping a static PNG) so the emoji matches
+// the user's OS font. The score badge from setBadgeText draws on top, so
+// users still see the fit score for any job they've previously scored.
+async function paintBriefcaseIcon() {
+  const sizes = [16, 32];
+  const imageData = {};
+  for (const size of sizes) {
+    const canvas = new OffscreenCanvas(size, size);
+    const ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, size, size);
+    // Slightly under-fill so the emoji has room to breathe at the edges.
+    ctx.font = `${Math.round(size * 0.85)}px "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif`;
+    ctx.textBaseline = "middle";
+    ctx.textAlign = "center";
+    ctx.fillText("💼", size / 2, size / 2 + size * 0.04);
+    imageData[size] = ctx.getImageData(0, 0, size, size);
+  }
+  try {
+    await browser.action.setIcon({ imageData });
+  } catch (err) {
+    console.warn("Failed to paint briefcase icon:", err);
+  }
+}
+paintBriefcaseIcon();
+
+// Badge text reflects the cached fit-score for the active tab's URL. Set
+// per-tab so switching tabs surfaces the score for whichever posting is in
+// front. Tabs with no cached score show no badge.
+// Update the toolbar badge for `tab`.
+//
+// `allowClear` controls what happens when we don't find a score:
+//   true  — actively clear the badge (used when the URL changed to a page
+//           that genuinely has no score)
+//   false — leave any existing badge alone (used for transient events like
+//           focus changes, popup close, status:complete refires)
+//
+// The asymmetry matters: Firefox fires `tabs.onActivated` when the action
+// popup closes, and `tab.url` is sometimes briefly empty / storage reads can
+// momentarily miss. Without `allowClear=false`, those transient signals
+// would wipe a perfectly-good badge.
+async function updateBadgeForTab(tab, { allowClear = true } = {}) {
+  if (!tab?.id || !tab.url) return;
+
+  if (!isScoreableUrl(tab.url)) {
+    if (allowClear) await paintBadgeForTab(tab.id, null);
+    return;
+  }
+
+  // Cache first. On miss, ask the backend — covers (a) entries lost to URL
+  // canonicalization, (b) jobs scored on another browser, (c) freshly-installed
+  // extension instances that haven't seen this URL yet.
+  let entry = await getCachedScore(tab.url);
+  if (!entry) {
+    const { backendUrl } = await browser.storage.local.get(["backendUrl"]);
+    if (backendUrl) {
+      entry = await lookupBackendScore(tab.url, backendUrl);
+      if (entry) {
+        try { await setCachedScore(tab.url, entry); } catch { /* ignore */ }
+      }
+    }
+  }
+
+  const score = fitScoreFromCacheEntry(entry);
+  if (score != null) {
+    await paintBadgeForTab(tab.id, score);
+  } else if (allowClear) {
+    await paintBadgeForTab(tab.id, null);
+  }
+  // else: keep the existing badge — a transient event shouldn't wipe it.
+}
+
+browser.tabs.onActivated.addListener(async ({ tabId }) => {
+  const tab = await browser.tabs.get(tabId).catch(() => null);
+  // Tab focus changed; the URL hasn't necessarily changed. Don't clear.
+  if (tab) await updateBadgeForTab(tab, { allowClear: false });
+});
+
+browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (changeInfo.url) {
+    // URL navigated to a new posting (or a non-job page). The previous
+    // badge is stale; clear if the new URL has no cached score.
+    await updateBadgeForTab(tab, { allowClear: true });
+  } else if (changeInfo.status === "complete") {
+    // Page finished loading at same URL — refresh score, don't clear.
+    await updateBadgeForTab(tab, { allowClear: false });
+  }
+});
+
+// Cache write from the popup — refresh the active tab's badge but never
+// clear it from this path (the popup's own painting already cleared it
+// if it needed to, and a tab-event will catch any stragglers).
+browser.storage.onChanged.addListener(async (changes, area) => {
+  if (area !== "local" || !changes.scoreCache) return;
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  if (tab) await updateBadgeForTab(tab, { allowClear: false });
+});
+
+// Initial paint on startup. Allow clearing here so a stale badge from a
+// previous session doesn't survive into a non-job tab.
+(async () => {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  if (tab) await updateBadgeForTab(tab, { allowClear: true });
+})();

--- a/job-board/firefox-plugin/lib.js
+++ b/job-board/firefox-plugin/lib.js
@@ -1,0 +1,259 @@
+"use strict";
+
+// Shared helpers used by both popup.js and background.js. Loaded as the first
+// script in popup.html and as the first entry in the background "scripts" array
+// in manifest.json, so its top-level symbols are available to both contexts.
+
+const SCORE_CACHE_KEY = "scoreCache";
+const SCORE_CACHE_MAX = 200;
+
+// Tracking params that don't identify the posting. Keep in sync with the
+// backend's `_TRACKING_PARAMS` (app.py) so plugin cache lookups and backend
+// dedupe land on the same string.
+const TRACKING_PARAMS = new Set([
+  "gh_src", "utm_source", "utm_medium", "utm_campaign", "utm_term",
+  "utm_content", "ref", "source", "lever-origin", "lever-source",
+]);
+
+// Stable cache key for a job posting. Same posting reached via different
+// surfaces — LinkedIn ?currentJobId vs /jobs/view/, Greenhouse embed wrapper
+// (voxel51.com/jd?gh_jid=N) vs Greenhouse direct (job-boards.greenhouse.io/
+// voxel51/jobs/N) — maps to a single key here. Mirrors the backend's
+// `urls.compute_dedupe_key` so plugin cache hits, backend lookups, and
+// inbox dedupe all agree. Returns an opaque string; callers treat it only
+// as a Map key, never as a clickable URL.
+function canonicalizeJobUrl(rawUrl) {
+  if (!rawUrl) return rawUrl;
+  try {
+    const u = new URL(rawUrl);
+
+    // LinkedIn — collapse recommended-list and direct-view to one form.
+    if (u.hostname.includes("linkedin.com")) {
+      let jobId = u.searchParams.get("currentJobId");
+      if (!jobId) {
+        const m = u.pathname.match(/\/jobs\/view\/(\d+)/);
+        if (m) jobId = m[1];
+      }
+      if (jobId) return `linkedin:${jobId}`;
+    }
+
+    // Greenhouse: any URL form with gh_jid (in query OR path on a *.greenhouse.io
+    // host) collapses to `gh:<id>`. Strips the host entirely so wrapper and
+    // direct URLs share a key.
+    let ghJid = u.searchParams.get("gh_jid");
+    if (!ghJid && u.hostname.endsWith("greenhouse.io")) {
+      const m = u.pathname.match(/^\/[^/]+\/jobs\/(\d+)\/?$/);
+      if (m) ghJid = m[1];
+    }
+    if (ghJid) return `gh:${ghJid}`;
+
+    // Ashby: ashby_jid query param (embed wrapper on any host, e.g.
+    // www.ashbyhq.com/careers?ashby_jid=<uuid>) or UUID at the end of the
+    // path on jobs.ashbyhq.com. Use the UUID's first stanza to keep keys
+    // tidy.
+    let ashbyJid = u.searchParams.get("ashby_jid");
+    if (!ashbyJid && u.hostname === "jobs.ashbyhq.com") {
+      const m = u.pathname.match(/^\/[^/]+\/([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})\/?$/i);
+      if (m) ashbyJid = m[1];
+    }
+    if (ashbyJid) return `ashby:${ashbyJid.split("-")[0]}`;
+
+    // Generic: drop tracking params, strip trailing slash on the path. Stays
+    // as a URL because there's no opaque id to extract.
+    const kept = new URLSearchParams();
+    for (const [k, v] of u.searchParams) {
+      if (!TRACKING_PARAMS.has(k)) kept.append(k, v);
+    }
+    let path = u.pathname;
+    if (path.length > 1 && path.endsWith("/")) path = path.replace(/\/+$/, "");
+    const q = kept.toString();
+    return `${u.protocol}//${u.host}${path}${q ? "?" + q : ""}`;
+  } catch {
+    return rawUrl;
+  }
+}
+
+// Only http(s) pages can host a real job posting. file:// and chrome:// and
+// about: tabs are skipped — no point spending an API call on them.
+function isScoreableUrl(rawUrl) {
+  if (!rawUrl) return false;
+  try {
+    const u = new URL(rawUrl);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// Path patterns that strongly suggest a careers-index page (list of
+// openings) rather than a specific job posting. Used to skip scoring on
+// pages like company.com/careers/ where the extracted text is a wall of
+// role titles, not a single JD.
+const CAREERS_INDEX_PATHS = [
+  /\/careers\/?$/i,
+  /\/jobs\/?$/i,
+  /\/open-positions\/?$/i,
+  /\/openings\/?$/i,
+  /\/positions\/?$/i,
+  /\/join(-us)?\/?$/i,
+  /\/work-with-us\/?$/i,
+  /\/hiring\/?$/i,
+  /\/we-are-hiring\/?$/i,
+];
+
+// Job-specifier query params that turn an otherwise careers-index URL into
+// a deep-link at a specific posting. When any of these is present, treat
+// the URL as a job listing, not an index.
+const JOB_SPECIFIER_PARAMS = ["gh_jid", "ashby_jid", "currentJobId"];
+
+function isCareersIndexUrl(rawUrl) {
+  if (!rawUrl) return false;
+  try {
+    const u = new URL(rawUrl);
+    for (const p of JOB_SPECIFIER_PARAMS) {
+      if (u.searchParams.get(p)) return false;
+    }
+    return CAREERS_INDEX_PATHS.some((re) => re.test(u.pathname));
+  } catch {
+    return false;
+  }
+}
+
+// True if `rawUrl` is hosted by the user's own job-store backend. Used to
+// short-circuit scoring when the user opens the popup on their inbox or
+// companies page — those pages contain job text that would otherwise get
+// scored as if it were a single posting.
+function isOwnBackendUrl(rawUrl, backendUrl) {
+  if (!rawUrl || !backendUrl) return false;
+  try {
+    const u = new URL(rawUrl);
+    const b = new URL(backendUrl);
+    return u.origin === b.origin;
+  } catch {
+    return false;
+  }
+}
+
+// Given any URL on a job board, return the canonical "careers URL" the
+// backend's `/companies` endpoint will recognize, or null if the page isn't
+// on one of the four ATSes the poller supports today (greenhouse / ashby /
+// lever / workday). Used by the popup's "watch this company" button.
+function deriveCareersUrl(rawUrl) {
+  if (!rawUrl) return null;
+  let u;
+  try { u = new URL(rawUrl); } catch { return null; }
+  const host = u.hostname;
+  const segs = u.pathname.split("/").filter(Boolean);
+
+  // Greenhouse: boards.greenhouse.io/<board>/... or job-boards.greenhouse.io/<board>/...
+  if (host.endsWith("greenhouse.io") && segs.length >= 1) {
+    return `https://boards.greenhouse.io/${segs[0]}`;
+  }
+  // Ashby: jobs.ashbyhq.com/<org>/...
+  if (host === "jobs.ashbyhq.com" && segs.length >= 1) {
+    return `https://jobs.ashbyhq.com/${segs[0]}`;
+  }
+  // Lever: jobs.lever.co/<company>/...
+  if (host === "jobs.lever.co" && segs.length >= 1) {
+    return `https://jobs.lever.co/${segs[0]}`;
+  }
+  // Workday: <tenant>.<region>.myworkdayjobs.com/<lang>/<site>/...
+  // The path is typically /<lang>/<site>/job/... so we need both first two
+  // segments to construct the careers URL the backend's regex matches.
+  if (host.endsWith(".myworkdayjobs.com") && segs.length >= 2) {
+    return `https://${host}/${segs[0]}/${segs[1]}`;
+  }
+  return null;
+}
+
+async function getCachedScore(rawUrl) {
+  const key = canonicalizeJobUrl(rawUrl);
+  if (!key) return null;
+  const data = await browser.storage.local.get(SCORE_CACHE_KEY);
+  const cache = data[SCORE_CACHE_KEY] || {};
+  return cache[key] || null;
+}
+
+// Extract the displayable score from a cache entry. Tolerant of both the new
+// Gemini-aligned analysis (`candidate_score`) and old plugin-direct entries
+// (`fit_score`). Returns null if there's no usable number.
+function fitScoreFromCacheEntry(entry) {
+  const fit = entry?.fit;
+  if (!fit) return null;
+  const v = fit.candidate_score ?? fit.fit_score;
+  return typeof v === "number" ? v : null;
+}
+
+// Ask the backend whether it has a score for this URL. Returns a cache-entry
+// shape on hit, null on miss. Used by the toolbar-badge path when the local
+// cache doesn't have an answer — covers jobs scored on another machine, after
+// a cache eviction, or before URL canonicalization invalidated old entries.
+async function lookupBackendScore(rawUrl, backendUrl) {
+  if (!rawUrl || !backendUrl) return null;
+  try {
+    const r = await fetch(
+      `${backendUrl.replace(/\/$/, "")}/jobs/score?url=${encodeURIComponent(rawUrl)}`,
+      { method: "GET" },
+    );
+    if (!r.ok) return null;
+    const data = await r.json();
+    if (data?.analysis == null) return null;
+    return {
+      job: { url: rawUrl, ats: null, title: null, description: "" },
+      fit: data.analysis,
+      usage: {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function setCachedScore(rawUrl, entry) {
+  const key = canonicalizeJobUrl(rawUrl);
+  if (!key || key === "manual-paste") return;
+  const data = await browser.storage.local.get(SCORE_CACHE_KEY);
+  const cache = data[SCORE_CACHE_KEY] || {};
+  cache[key] = { ...entry, timestamp: Date.now() };
+
+  // Evict oldest entries beyond the cap to keep storage bounded.
+  const keys = Object.keys(cache);
+  if (keys.length > SCORE_CACHE_MAX) {
+    keys.sort((a, b) => (cache[a].timestamp || 0) - (cache[b].timestamp || 0));
+    for (const k of keys.slice(0, keys.length - SCORE_CACHE_MAX)) {
+      delete cache[k];
+    }
+  }
+
+  await browser.storage.local.set({ [SCORE_CACHE_KEY]: cache });
+}
+
+// Map a 0-100 score to a recommendation bucket and matching badge color. Kept
+// out of popup.js so the background script can pick a badge background that
+// matches the popup's score-circle colors.
+function badgeColorForScore(score) {
+  if (score >= 80) return "#28a745"; // strong match — green
+  if (score >= 60) return "#17a2b8"; // consider — teal
+  if (score >= 40) return "#ffc107"; // weak — yellow
+  return "#dc3545";                  // skip — red
+}
+
+// Single source of truth for painting the toolbar badge. Used from both the
+// background script (on tab events / storage changes) and the popup (right
+// after a successful render, as a defensive belt-and-suspenders so the user
+// sees the score without waiting on the storage.onChanged round-trip).
+async function paintBadgeForTab(tabId, score) {
+  if (tabId == null) return;
+  try {
+    if (typeof score !== "number") {
+      await browser.action.setBadgeText({ tabId, text: "" });
+      return;
+    }
+    await browser.action.setBadgeText({ tabId, text: String(Math.round(score)) });
+    await browser.action.setBadgeBackgroundColor({ tabId, color: badgeColorForScore(score) });
+    if (browser.action.setBadgeTextColor) {
+      await browser.action.setBadgeTextColor({ tabId, color: "#ffffff" });
+    }
+  } catch (err) {
+    console.warn("paintBadgeForTab failed:", err);
+  }
+}

--- a/job-board/firefox-plugin/manifest.json
+++ b/job-board/firefox-plugin/manifest.json
@@ -1,0 +1,46 @@
+{
+  "manifest_version": 3,
+  "name": "Job Fit Scorer",
+  "version": "0.1.0",
+  "description": "Score job postings against your resume using Claude Haiku 4.5.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "job-fit-scorer@devdull.lol",
+      "strict_min_version": "115.0"
+    }
+  },
+  "background": {
+    "scripts": ["lib.js", "background.js"]
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Score this job"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
+  "permissions": [
+    "storage",
+    "activeTab",
+    "scripting"
+  ],
+  "optional_host_permissions": [
+    "*://*/*"
+  ],
+  "host_permissions": [
+    "http://127.0.0.1/*",
+    "http://localhost/*",
+    "https://*.greenhouse.io/*",
+    "https://*.ashbyhq.com/*",
+    "https://jobs.lever.co/*",
+    "https://*.myworkdayjobs.com/*",
+    "https://*.icims.com/*",
+    "https://www.linkedin.com/jobs/*",
+    "https://*.bamboohr.com/*",
+    "https://apply.workable.com/*",
+    "https://jobs.gem.com/*",
+    "https://*.ats.rippling.com/*",
+    "https://careers.ibm.com/*"
+  ]
+}

--- a/job-board/firefox-plugin/options.css
+++ b/job-board/firefox-plugin/options.css
@@ -1,0 +1,119 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  background: #fafafa;
+  margin: 0;
+}
+
+main {
+  max-width: 720px;
+  margin: 40px auto;
+  padding: 30px;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+}
+
+h1 {
+  font-size: 18px;
+  margin: 0 0 24px;
+}
+
+section {
+  margin-bottom: 28px;
+}
+
+label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+p.help {
+  margin: 4px 0 10px;
+  color: #555;
+  font-size: 12px;
+}
+p.help.meta { color: #888; }
+p.help.meta.error, p.help.warning { color: #b00020; }
+p.help.warning {
+  background: #fff8e1;
+  border-left: 3px solid #f0ad4e;
+  padding: 6px 10px;
+  color: #6b4f10;
+}
+
+.optional {
+  font-weight: normal;
+  color: #888;
+  font-size: 12px;
+}
+
+input[type="file"] {
+  flex: 1;
+  font-size: 12px;
+  padding: 4px 0;
+}
+
+a { color: #1a4f8b; }
+code {
+  background: #f0f0f0;
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+}
+
+input[type="password"], input[type="text"] {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-family: monospace;
+  font-size: 13px;
+}
+
+textarea {
+  width: 100%;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  resize: vertical;
+}
+
+button {
+  padding: 8px 16px;
+  border: 1px solid #ccc;
+  background: #fafafa;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+}
+button.primary {
+  background: #1a1a1a;
+  color: #fff;
+  border-color: #1a1a1a;
+}
+button:hover { opacity: 0.85; }
+
+.status {
+  margin-left: 12px;
+  font-size: 12px;
+  color: #2d7a3a;
+}
+.status.error { color: #b00020; }
+
+.footer {
+  border-top: 1px solid #eee;
+  padding-top: 16px;
+  margin-bottom: 0;
+}

--- a/job-board/firefox-plugin/options.html
+++ b/job-board/firefox-plugin/options.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Job Fit Scorer — Settings</title>
+  <link rel="stylesheet" href="options.css">
+</head>
+<body>
+  <main>
+    <h1>Job Fit Scorer — Settings</h1>
+
+    <p class="help">
+      All scoring happens on the <code>job-store</code> backend. The backend holds
+      the resume, the API key, the model, and the prompt — the plugin just sends
+      job descriptions and renders responses.
+    </p>
+
+    <section>
+      <label for="backend-url">Job-store backend URL</label>
+      <p class="help">
+        URL of the <code>job-store</code> Flask backend
+        (e.g. <code>http://127.0.0.1:5000</code> for local dev,
+        <code>https://jobs.example.com</code> for hosted).
+      </p>
+      <p class="help">
+        Localhost URLs work out of the box. Any other host triggers a one-time
+        Firefox permission prompt the first time you Save or Test —
+        accept it to let the extension reach that host.
+      </p>
+      <div class="row">
+        <input type="text" id="backend-url" placeholder="http://127.0.0.1:5000">
+        <button id="test-backend" type="button">Test</button>
+      </div>
+      <p class="help meta" id="backend-status"></p>
+    </section>
+
+    <section>
+      <button id="save" class="primary" type="button">Save settings</button>
+      <span id="save-status" class="status"></span>
+    </section>
+
+    <section class="footer">
+      <p class="help">
+        Resume edits happen on the backend host
+        (<code>resume_details.yaml</code> in the job-store working directory) —
+        not here. Career-growth keywords are configured via the
+        <code>GROWTH_KEYWORDS</code> env var on the backend.
+      </p>
+    </section>
+  </main>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/job-board/firefox-plugin/options.js
+++ b/job-board/firefox-plugin/options.js
@@ -1,0 +1,112 @@
+"use strict";
+
+const $ = (id) => document.getElementById(id);
+
+// Storage keys carried by older builds. Removed on load so they don't linger
+// in browser.storage.local forever after the migration to server-side scoring.
+const DEPRECATED_KEYS = [
+  "apiKey", "resume", "resumePath", "resumeLoadedAt", "growthKeywords",
+];
+
+// Hosts already covered by the static `host_permissions` in manifest.json —
+// no runtime grant needed (or possible). Kept in sync with the manifest;
+// don't add the cluster hostname here, that goes through optional perms.
+function isStaticallyPermittedHost(url) {
+  try {
+    const h = new URL(url).hostname;
+    return h === "127.0.0.1" || h === "localhost";
+  } catch {
+    return false;
+  }
+}
+
+// Ensure the extension can fetch from the given backend origin.
+//
+// Firefox enforces that `browser.permissions.request()` is called from a
+// user-gesture context; any `await` between the gesture and the request
+// invalidates that. So the function does all setup synchronously and uses
+// `request()` as its only async call. We skip `permissions.contains()`
+// entirely — Firefox's request() is a silent no-op if the permission is
+// already granted (saving the extra await that broke the previous version).
+async function ensureBackendPermission(url) {
+  let origin;
+  try { origin = new URL(url).origin; } catch { return { ok: false, reason: "invalid URL" }; }
+  if (isStaticallyPermittedHost(url)) return { ok: true };
+  const pattern = `${origin}/*`;
+  try {
+    const granted = await browser.permissions.request({ origins: [pattern] });
+    return granted
+      ? { ok: true }
+      : { ok: false, reason: "permission denied — extension can't reach this URL until granted" };
+  } catch (err) {
+    return { ok: false, reason: `permissions error: ${err.message}` };
+  }
+}
+
+async function load() {
+  // Best-effort cleanup of pre-server-side-scoring storage keys. Safe even
+  // if some keys were never set.
+  try { await browser.storage.local.remove(DEPRECATED_KEYS); } catch { /* ignore */ }
+
+  const { backendUrl } = await browser.storage.local.get(["backendUrl"]);
+  if (backendUrl) $("backend-url").value = backendUrl;
+}
+
+async function save() {
+  const backendUrl = $("backend-url").value.trim().replace(/\/$/, "");
+  const status = $("save-status");
+
+  if (!backendUrl) {
+    status.classList.add("error");
+    status.textContent = "Backend URL is required.";
+    return;
+  }
+
+  // For non-localhost backends, prompt the user to grant cross-origin
+  // permission before saving. Without it, the popup and the score POST
+  // would silently fail with a CORS error.
+  const perm = await ensureBackendPermission(backendUrl);
+  if (!perm.ok) {
+    status.classList.add("error");
+    status.textContent = `Backend URL not saved: ${perm.reason}.`;
+    return;
+  }
+
+  await browser.storage.local.set({ backendUrl });
+  status.classList.remove("error");
+  status.textContent = "Saved.";
+  setTimeout(() => (status.textContent = ""), 2000);
+}
+
+async function testBackend() {
+  const url = $("backend-url").value.trim().replace(/\/$/, "");
+  const status = $("backend-status");
+  status.classList.remove("error");
+  if (!url) {
+    status.classList.add("error");
+    status.textContent = "Set a backend URL first.";
+    return;
+  }
+  // Request permission first if needed — same gesture-required pattern as save().
+  const perm = await ensureBackendPermission(url);
+  if (!perm.ok) {
+    status.classList.add("error");
+    status.textContent = `Can't reach ${url}: ${perm.reason}.`;
+    return;
+  }
+  status.textContent = "Pinging…";
+  try {
+    const r = await fetch(`${url}/jobs?status=open`, { method: "GET" });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    const list = await r.json();
+    status.textContent = `Reachable. Currently ${list.length} open jobs in inbox.`;
+  } catch (err) {
+    status.classList.add("error");
+    status.textContent = `Couldn't reach ${url}: ${err.message}`;
+  }
+}
+
+$("save").addEventListener("click", save);
+$("test-backend").addEventListener("click", testBackend);
+
+load();

--- a/job-board/firefox-plugin/popup.css
+++ b/job-board/firefox-plugin/popup.css
@@ -1,0 +1,215 @@
+* { box-sizing: border-box; }
+
+body {
+  width: 380px;
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 13px;
+  color: #1a1a1a;
+  background: #fff;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+header h1 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+}
+
+header a {
+  color: #666;
+  text-decoration: none;
+  font-size: 16px;
+}
+
+main {
+  padding: 14px;
+}
+
+p { margin: 0 0 10px; }
+
+button {
+  font-size: 13px;
+  padding: 6px 14px;
+  border: 1px solid #ccc;
+  background: #fafafa;
+  border-radius: 4px;
+  cursor: pointer;
+}
+button.primary {
+  background: #1a1a1a;
+  color: #fff;
+  border-color: #1a1a1a;
+}
+button.secondary {
+  background: #fff;
+  margin-top: 10px;
+}
+button:hover { opacity: 0.85; }
+
+textarea {
+  width: 100%;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  resize: vertical;
+}
+
+.empty, .empty-hint { color: #555; }
+.empty-hint { font-size: 12px; margin-bottom: 6px; }
+
+.actions-prompt {
+  font-weight: 600;
+  margin: 0 0 8px;
+  color: #1a1a1a;
+}
+
+.spinner {
+  width: 22px; height: 22px;
+  border: 2px solid #e0e0e0;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  margin: 12px auto 0;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.error { color: #b00020; }
+
+.score-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 12px;
+}
+
+.score-circle {
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 24px;
+  font-weight: 700;
+  background: #eee;
+  color: #333;
+  flex-shrink: 0;
+}
+.score-circle.s-strong { background: #d4edda; color: #155724; }
+.score-circle.s-consider { background: #d1ecf1; color: #0c5460; }
+.score-circle.s-weak { background: #fff3cd; color: #856404; }
+.score-circle.s-skip { background: #f8d7da; color: #721c24; }
+
+.recommendation {
+  flex: 1;
+}
+.rec-label {
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 2px;
+}
+.ats { color: #888; font-size: 11px; text-transform: uppercase; letter-spacing: 0.4px; }
+
+.subscores {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+.subscore {
+  font-size: 11px;
+  color: #4a5b6f;
+  background: #eef2f7;
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.explanation-text {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #333;
+  white-space: pre-wrap;
+}
+
+.summary {
+  background: #f5f5f5;
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-style: italic;
+}
+
+details { margin-bottom: 8px; }
+summary { cursor: pointer; font-weight: 600; padding: 4px 0; }
+details ul { margin: 4px 0 8px; padding-left: 20px; }
+details li { margin-bottom: 4px; }
+
+.meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  color: #888;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #eee;
+}
+
+.cache-info { font-family: monospace; }
+
+.save-status {
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+.save-status.ok { background: #d4edda; color: #155724; }
+.save-status.warn { background: #fff3cd; color: #856404; }
+.save-status.err { background: #f8d7da; color: #721c24; }
+
+.cache-notice {
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  background: #eef2f7;
+  color: #4a5b6f;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.watch-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: #f7f9fc;
+  border-bottom: 1px solid #e5e5e5;
+  font-size: 12px;
+}
+/* Class selector beats [hidden]'s default `display: none` on specificity ties
+   (both 0,1,0; .watch-bar declared later wins). Re-assert here so toggling
+   the `hidden` attribute from JS actually hides the bar. */
+.watch-bar[hidden] { display: none; }
+.watch-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+}
+.watch-btn.is-watched {
+  background: #d4edda;
+  border-color: #b6dfc1;
+  color: #155724;
+  cursor: default;
+}
+.watch-status {
+  color: #555;
+}
+.watch-status.err { color: #b00020; }

--- a/job-board/firefox-plugin/popup.html
+++ b/job-board/firefox-plugin/popup.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Job Fit Scorer</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <header>
+    <h1>Job Fit Scorer</h1>
+    <a href="#" id="open-options" title="Settings">⚙</a>
+  </header>
+
+  <div id="watch-bar" class="watch-bar" hidden>
+    <button id="watch-btn" type="button" class="watch-btn"></button>
+    <span id="watch-status" class="watch-status"></span>
+  </div>
+
+  <main id="status-empty" hidden>
+    <p class="empty">No job posting detected on this page.</p>
+    <p class="empty-hint">Paste a job description below to score it manually:</p>
+    <textarea id="manual-jd" placeholder="Paste job description here..." rows="6"></textarea>
+    <button id="manual-score" class="primary">Score this</button>
+  </main>
+
+  <main id="status-self" hidden>
+    <p class="empty">You're on the Job Inbox — nothing to score here.</p>
+    <p class="empty-hint">Open a job posting in another tab, or use settings to update the resume/key.</p>
+  </main>
+
+  <main id="status-careers-index" hidden>
+    <p class="empty">This looks like a careers index, not a specific job posting.</p>
+    <p class="empty-hint">Click into an individual role on this page to score it. If the company is on a supported ATS, the watch bar above lets you add it for periodic polling.</p>
+  </main>
+
+  <main id="status-actions" hidden>
+    <p class="actions-prompt">Score this page against your resume?</p>
+    <button id="score-action" class="primary">Evaluate this job listing</button>
+    <p class="empty-hint">
+      Sends the page's job description to your job-store, which scores it via
+      Anthropic. Typically ~$0.01 per evaluation. Use the watch bar above
+      instead if this is a careers index, not a single posting.
+    </p>
+  </main>
+
+  <main id="status-loading" hidden>
+    <p>Analyzing against your resume...</p>
+    <div class="spinner"></div>
+  </main>
+
+  <main id="status-error" hidden>
+    <p class="error" id="error-message"></p>
+    <button id="error-retry">Retry</button>
+    <button id="error-options">Open settings</button>
+  </main>
+
+  <main id="status-result" hidden>
+    <div class="score-row">
+      <div class="score-circle" id="score-circle">
+        <span id="score-number">--</span>
+      </div>
+      <div class="recommendation">
+        <div id="recommendation-label" class="rec-label"></div>
+        <div id="ats-platform" class="ats"></div>
+        <div class="subscores">
+          <span id="growth-subscore" class="subscore" hidden></span>
+        </div>
+      </div>
+    </div>
+
+    <p id="summary" class="summary"></p>
+
+    <details id="explanation-section" hidden>
+      <summary>Full explanation</summary>
+      <p id="explanation" class="explanation-text"></p>
+    </details>
+
+    <details open>
+      <summary>Strengths</summary>
+      <ul id="strengths"></ul>
+    </details>
+
+    <details>
+      <summary>Gaps</summary>
+      <ul id="gaps"></ul>
+    </details>
+
+    <div class="meta">
+      <span id="job-title"></span>
+      <span id="jd-score" class="cache-info" hidden></span>
+      <span id="cache-info" class="cache-info"></span>
+    </div>
+
+    <div id="save-status" class="save-status" hidden></div>
+
+    <div id="cache-notice" class="cache-notice" hidden></div>
+
+    <button id="rescore" class="secondary">Re-score</button>
+  </main>
+
+  <script src="lib.js"></script>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/job-board/firefox-plugin/popup.js
+++ b/job-board/firefox-plugin/popup.js
@@ -1,0 +1,701 @@
+"use strict";
+
+// The plugin is a thin client: extracts the JD from the current tab and POSTs
+// it to the job-store backend, which holds the resume, the API key, the
+// prompt, and the schema. All scoring is server-side — the poller and the
+// plugin share one codepath. See SERVER_SIDE_SCORING.md.
+
+const ATS_HOSTS = [
+  ["greenhouse.io", "greenhouse"],
+  ["ashbyhq.com", "ashby"],
+  ["lever.co", "lever"],
+  ["myworkdayjobs.com", "workday"],
+  ["linkedin.com", "linkedin"],
+  ["icims.com", "icims"],
+  ["bamboohr.com", "bamboo"],
+  ["workable.com", "workable"],
+  ["gem.com", "gem"],
+  ["rippling.com", "rippling"],
+  ["careers.ibm.com", "ibm"],
+];
+
+// ---------------------------------------------------------------------------
+// DOM helpers
+// ---------------------------------------------------------------------------
+
+const $ = (id) => document.getElementById(id);
+const showOnly = (id) => {
+  for (const el of document.querySelectorAll("main")) el.hidden = true;
+  $(id).hidden = false;
+};
+
+document.getElementById("open-options").addEventListener("click", (e) => {
+  e.preventDefault();
+  browser.runtime.openOptionsPage();
+});
+
+// ---------------------------------------------------------------------------
+// Page extraction (runs in the page context)
+// ---------------------------------------------------------------------------
+
+function extractInPage() {
+  const url = location.href;
+  const hostname = location.hostname;
+  // LinkedIn split-pane (`/jobs/collections/.../?currentJobId=N`) renders a
+  // page-level h1 like "Recommended for you" — the actual job title lives in
+  // the detail pane. Try the unified-top-card class first.
+  const titleEl =
+    document.querySelector("[class*='jobs-unified-top-card__job-title']") ||
+    document.querySelector("h1");
+  const title = (titleEl?.innerText || document.title || "").trim();
+
+  // Two-tier extraction. Tier 1 is ATS-specific selectors known to wrap just
+  // the description — if any match with substantial text we prefer them, since
+  // they beat generic containers that often include navigation chrome or, on
+  // LinkedIn split-pane views, the entire left-rail job list.
+  const HIGH_CONFIDENCE = [
+    // LinkedIn — class names rotate, so prefer wildcard plus known variants
+    ".jobs-description__content",
+    ".jobs-description-content__text",
+    ".jobs-box__html-content",
+    ".jobs-description",
+    "[class*='jobs-description']",
+    // IBM careers.ibm.com — article__content__view is just the role
+    // description; section__content also includes "ABOUT BUSINESS UNIT".
+    ".article__content__view",
+    ".section__content",
+    // Workday
+    "[data-automation-id='jobPostingDescription']",
+  ].join(", ");
+
+  // Tier 2: generic SPA / careers-site patterns. Longest-wins among these.
+  const GENERIC = [
+    "main",
+    "article",
+    "[role='main']",
+    ".job",
+    ".posting",
+    ".opening",
+    "#content",
+    "#job-description",
+    ".description",
+    "[data-testid*='job']",
+    "[data-testid*='description']",
+    "[class*='job-description']",
+    "[class*='JobDescription']",
+    "[class*='job-detail']",
+    "[class*='JobDetail']",
+    "[id*='job-description']",
+    "[id*='JobDescription']",
+    ".phs-jobs-content",  // Phenom
+  ].join(", ");
+
+  const pickLongest = (selectorString) => {
+    let bestEl = null;
+    let bestLen = 0;
+    for (const el of document.querySelectorAll(selectorString)) {
+      const len = (el.innerText || "").length;
+      if (len > bestLen && len < 50000) {
+        bestLen = len;
+        bestEl = el;
+      }
+    }
+    return { el: bestEl, len: bestLen };
+  };
+
+  let main = null;
+  let bestLen = 0;
+
+  // LinkedIn anchor extraction — class names rotate frequently, but the
+  // section header text "About the job" is stable English copy. Find that
+  // header and walk up to the smallest ancestor with substantial text. This
+  // beats class-based extraction in robustness and bypasses the issue where
+  // the longest-text container on a split-pane recommended-jobs page is the
+  // "Top job picks" feed sidebar rather than the description itself.
+  if (hostname.includes("linkedin.com")) {
+    for (const h of document.querySelectorAll("h1, h2, h3, h4")) {
+      if (!/^about the job\b/i.test((h.innerText || "").trim())) continue;
+      let walker = h;
+      while (walker.parentElement && (walker.innerText || "").length < 1500) {
+        walker = walker.parentElement;
+      }
+      const len = (walker.innerText || "").length;
+      if (len >= 1500 && len < 50000) {
+        main = walker;
+        bestLen = len;
+      }
+      break;
+    }
+  }
+
+  if (!main) {
+    ({ el: main, len: bestLen } = pickLongest(HIGH_CONFIDENCE));
+    if (bestLen < 200) {
+      main = null;
+      bestLen = 0;
+    }
+  }
+  if (!main) ({ el: main, len: bestLen } = pickLongest(GENERIC));
+  if (!main) ({ el: main } = pickLongest("div, section"));
+  const description = (main?.innerText || document.body.innerText || "").trim();
+
+  // If this page embeds Greenhouse via their JS embed (`<script src=
+  // "boards.greenhouse.io/embed/job_board/js?for=<token>">`), surface the
+  // board token so the popup can fetch the canonical job from the API
+  // — generic page-scrape can't see across the iframe Greenhouse injects.
+  let greenhouseBoardToken = null;
+  for (const s of document.querySelectorAll("script[src*='greenhouse.io/embed']")) {
+    const m = (s.src || "").match(/[?&]for=([^&]+)/);
+    if (m) { greenhouseBoardToken = m[1]; break; }
+  }
+
+  // Ashby embeds JS-render their JD post-load, so DOM extraction often
+  // misses it. Capture the org slug from any reference to jobs.ashbyhq.com
+  // on the page; the popup then fetches the canonical JD via Ashby's API.
+  let ashbyOrgSlug = null;
+  for (const el of document.querySelectorAll(
+        "script[src*='ashbyhq.com'], a[href*='jobs.ashbyhq.com'], iframe[src*='ashbyhq.com']")) {
+    const src = el.src || el.href || "";
+    const m = src.match(/jobs\.ashbyhq\.com\/([a-z0-9_-]+)/i);
+    if (m) { ashbyOrgSlug = m[1]; break; }
+  }
+  // ashbyhq.com's own marketing-site careers page hosts their internal
+  // postings under slug "ashby".
+  if (!ashbyOrgSlug && (hostname === "www.ashbyhq.com" || hostname === "ashbyhq.com")) {
+    ashbyOrgSlug = "ashby";
+  }
+
+  return { url, hostname, title, description, greenhouseBoardToken, ashbyOrgSlug };
+}
+
+function detectAts(hostname) {
+  for (const [needle, name] of ATS_HOSTS) {
+    if (hostname.includes(needle)) return name;
+  }
+  return "unknown";
+}
+
+async function extractCurrentTab() {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.id) throw new Error("No active tab.");
+  const results = await browser.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: extractInPage,
+  });
+  const extracted = results?.[0]?.result;
+  if (!extracted) throw new Error("Failed to extract page content.");
+  let job = { ...extracted, ats: detectAts(extracted.hostname) };
+
+  // Canonicalize LinkedIn URLs so the same posting reached via the
+  // recommended-list (`?currentJobId=<id>`) and via direct view
+  // (`/jobs/view/<id>/`) dedupe to the same job-store row.
+  if (job.hostname.includes("linkedin.com")) {
+    try {
+      const u = new URL(job.url);
+      let jobId = u.searchParams.get("currentJobId");
+      if (!jobId) {
+        const m = u.pathname.match(/\/jobs\/view\/(\d+)/);
+        if (m) jobId = m[1];
+      }
+      if (jobId) job.url = `https://www.linkedin.com/jobs/view/${jobId}/`;
+    } catch { /* leave URL alone if parsing fails */ }
+  }
+
+  // If we're on a Greenhouse-embedded page (any company hosting Greenhouse
+  // via their own domain — Outside Inc, etc.), the page-scraped description
+  // is just the company landing page. Fetch the canonical job content
+  // from Greenhouse's public job-board API instead. Works because the
+  // plugin has host_permissions for *.greenhouse.io, which lets the popup
+  // fetch despite the API not returning open CORS headers.
+  const ghJid = new URL(job.url).searchParams.get("gh_jid");
+  if (ghJid && job.greenhouseBoardToken) {
+    try {
+      const r = await fetch(
+        `https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(job.greenhouseBoardToken)}/jobs/${encodeURIComponent(ghJid)}`
+      );
+      if (r.ok) {
+        const data = await r.json();
+        const tmp = document.createElement("div");
+        tmp.innerHTML = data.content || "";
+        const plain = (tmp.innerText || tmp.textContent || "").trim();
+        if (plain.length > 200) {
+          job.title = data.title || job.title;
+          job.description = plain;
+          job.ats = "greenhouse";
+        }
+      }
+    } catch (err) {
+      console.warn("Greenhouse API fetch failed; falling back to page scrape:", err);
+    }
+  }
+
+  // Ashby same idea: the embed renders the JD client-side, so DOM extraction
+  // typically misses the actual posting text. Pull from the public posting
+  // API using the ashby_jid (query param on the embed wrapper, or UUID in
+  // the path on jobs.ashbyhq.com) plus the org slug surfaced by extractInPage.
+  const jobUrl = new URL(job.url);
+  let ashbyJid = jobUrl.searchParams.get("ashby_jid");
+  if (!ashbyJid && jobUrl.hostname === "jobs.ashbyhq.com") {
+    const m = jobUrl.pathname.match(/^\/[^/]+\/([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})\/?$/i);
+    if (m) ashbyJid = m[1];
+  }
+  if (ashbyJid && job.ashbyOrgSlug) {
+    try {
+      const r = await fetch(
+        `https://api.ashbyhq.com/posting-api/job-board/${encodeURIComponent(job.ashbyOrgSlug)}?includeCompensation=true`
+      );
+      if (r.ok) {
+        const data = await r.json();
+        const match = (data.jobs || []).find((j) => j.id === ashbyJid);
+        if (match) {
+          let desc = match.descriptionPlain || "";
+          if (!desc && match.descriptionHtml) {
+            const tmp = document.createElement("div");
+            tmp.innerHTML = match.descriptionHtml;
+            desc = (tmp.innerText || tmp.textContent || "").trim();
+          }
+          if (desc && desc.length > 200) {
+            job.title = match.title || job.title;
+            job.description = desc;
+            job.ats = "ashby";
+          }
+        }
+      }
+    } catch (err) {
+      console.warn("Ashby API fetch failed; falling back to page scrape:", err);
+    }
+  }
+
+  return job;
+}
+
+// ---------------------------------------------------------------------------
+// Backend score call — POSTs the raw JD; backend reads the resume from disk,
+// holds the API key, calls Anthropic, returns the analysis blob. One scoring
+// codepath shared with the targeted-company poller. See SERVER_SIDE_SCORING.md.
+// ---------------------------------------------------------------------------
+
+async function scoreViaBackend({ backendUrl, job, force = false }) {
+  const body = {
+    url: job.url,
+    title: job.title,
+    description: job.description,
+    ats_platform: job.ats,
+    discovered_by: "plugin",
+    // No fit_score / analysis — sending those would tell the backend to
+    // persist as-is and skip Anthropic; we want it to score.
+    // `force` bypasses the backend's "already scored" dedupe guard.
+    force,
+  };
+
+  const r = await fetch(`${backendUrl}/jobs/score`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!r.ok) {
+    const text = await r.text().catch(() => "");
+    throw new Error(`backend scoring failed: HTTP ${r.status} ${text.slice(0, 200)}`);
+  }
+
+  const data = await r.json();
+  // Backend returns the full analysis blob under `analysis` and surfaces
+  // top-level helpers (`fit_score`, `company`, `rank_score`) plus per-call
+  // token usage. Plugin only needs the analysis + usage for rendering.
+  return {
+    fit: data.analysis || {},
+    usage: data.usage || {},
+    rankScore: data.rank_score,
+    jobId: data.id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+const REC_LABELS = {
+  strong_match: { label: "Strong match", cls: "s-strong" },
+  consider: { label: "Consider", cls: "s-consider" },
+  weak_match: { label: "Weak match", cls: "s-weak" },
+  skip: { label: "Skip", cls: "s-skip" },
+};
+
+// Map a 1-100 candidate_score to a recommendation bucket. Derived client-side
+// from the score itself so the UI never disagrees with the number. Cutoffs
+// match the popup's previous prompt-baked calibration.
+function deriveRecommendation(score) {
+  if (score >= 80) return "strong_match";
+  if (score >= 60) return "consider";
+  if (score >= 40) return "weak_match";
+  return "skip";
+}
+
+// Tolerant adapter: maps either the old plugin schema (fit_score, company,
+// summary, strengths, gaps, recommendation) or the new Gemini-aligned schema
+// (candidate_score, job_company_name, candidate_explanation, ...) into the
+// canonical shape the UI renders. Lets cached entries from before the schema
+// migration keep displaying without a forced re-score.
+function normalizeFit(fit) {
+  return {
+    candidate_score: fit.candidate_score ?? fit.fit_score ?? 0,
+    career_growth_score: fit.career_growth_score ?? null,
+    candidate_explanation: fit.candidate_explanation ?? fit.summary ?? "",
+    candidate_strengths: fit.candidate_strengths ?? fit.strengths ?? [],
+    candidate_deficiencies: fit.candidate_deficiencies ?? fit.gaps ?? [],
+    job_description_score: fit.job_description_score ?? null,
+    job_company_name: fit.job_company_name ?? fit.company ?? null,
+  };
+}
+
+function firstSentence(text) {
+  if (!text) return "";
+  const m = text.match(/^[^.!?]*[.!?]/);
+  return (m ? m[0] : text).trim();
+}
+
+function renderResult(job, rawFit, usage) {
+  const fit = normalizeFit(rawFit);
+  const rec = REC_LABELS[deriveRecommendation(fit.candidate_score)] || REC_LABELS.consider;
+
+  const circle = $("score-circle");
+  circle.className = `score-circle ${rec.cls}`;
+  $("score-number").textContent = fit.candidate_score;
+  $("recommendation-label").textContent = rec.label;
+  $("ats-platform").textContent = job.ats !== "unknown" ? job.ats : "";
+  $("summary").textContent = firstSentence(fit.candidate_explanation);
+  const companyTitle = fit.job_company_name
+    ? `${fit.job_company_name} — ${job.title}`
+    : job.title;
+  $("job-title").textContent = companyTitle.slice(0, 70);
+
+  // Subscore badges — only rendered if the field is present (old cached
+  // entries from before the schema change leave them null).
+  const renderSubscore = (id, label, score) => {
+    const el = $(id);
+    if (score == null) {
+      el.hidden = true;
+      return;
+    }
+    el.hidden = false;
+    el.textContent = `${label} ${score}`;
+  };
+  renderSubscore("growth-subscore", "Growth", fit.career_growth_score);
+
+  const renderList = (id, items) => {
+    const ul = $(id);
+    ul.innerHTML = "";
+    for (const item of items) {
+      const li = document.createElement("li");
+      li.textContent = item;
+      ul.appendChild(li);
+    }
+  };
+  renderList("strengths", fit.candidate_strengths);
+  renderList("gaps", fit.candidate_deficiencies);
+
+  // Full explanation (up to 250 words) lives behind a details disclosure;
+  // the summary line already shows the first sentence.
+  const explanationSection = $("explanation-section");
+  if (fit.candidate_explanation && fit.candidate_explanation !== firstSentence(fit.candidate_explanation)) {
+    $("explanation").textContent = fit.candidate_explanation;
+    explanationSection.hidden = false;
+  } else {
+    explanationSection.hidden = true;
+  }
+
+  const jdScoreEl = $("jd-score");
+  if (fit.job_description_score != null) {
+    jdScoreEl.hidden = false;
+    jdScoreEl.textContent = `JD ${fit.job_description_score}/100`;
+  } else {
+    jdScoreEl.hidden = true;
+  }
+
+  const cacheRead = usage.cache_read_input_tokens || 0;
+  const cacheWrite = usage.cache_creation_input_tokens || 0;
+  const fresh = usage.input_tokens || 0;
+  const out = usage.output_tokens || 0;
+  $("cache-info").textContent =
+    cacheRead > 0
+      ? `${cacheRead} cached / ${fresh} fresh / ${out} out`
+      : `${fresh + cacheWrite} in / ${out} out`;
+
+  showOnly("status-result");
+}
+
+function renderSaveStatus(state) {
+  const el = $("save-status");
+  if (!state) {
+    el.hidden = true;
+    return;
+  }
+  el.hidden = false;
+  el.className = `save-status ${state.cls}`;
+  el.textContent = state.text;
+}
+
+function formatAge(timestamp) {
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function renderCacheNotice(state) {
+  const el = $("cache-notice");
+  if (!state) {
+    el.hidden = true;
+    el.textContent = "";
+    return;
+  }
+  el.hidden = false;
+  el.textContent = `Cached • scored ${formatAge(state.timestamp)}`;
+}
+
+function showError(message) {
+  $("error-message").textContent = message;
+  showOnly("status-error");
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+async function loadConfig() {
+  const { backendUrl } = await browser.storage.local.get(["backendUrl"]);
+  const trimmed = (backendUrl || "").trim().replace(/\/$/, "");
+  if (!trimmed) {
+    throw new Error("No backend URL configured. Open settings to set the job-store URL.");
+  }
+  return { backendUrl: trimmed };
+}
+
+async function getActiveTabUrl() {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  return tab?.url || null;
+}
+
+// Defensive: paint the toolbar badge directly from the popup after a
+// successful render. background.js also paints on storage.onChanged, but
+// this guarantees the user sees the badge the moment the popup shows the
+// score — independent of background-event timing.
+async function paintBadgeFromFit(fit) {
+  try {
+    const score = (typeof fit?.candidate_score === "number" ? fit.candidate_score
+                 : typeof fit?.fit_score === "number" ? fit.fit_score
+                 : null);
+    if (score == null) return;
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    if (tab?.id != null) await paintBadgeForTab(tab.id, score);
+  } catch (err) {
+    console.warn("paintBadgeFromFit failed:", err);
+  }
+}
+
+async function run({ manualJD = null, force = false } = {}) {
+  renderSaveStatus(null);
+  renderCacheNotice(null);
+
+  if (!manualJD) {
+    // Always-quiet states first — no scoring, no prompt.
+    try {
+      const tabUrl = await getActiveTabUrl();
+      const { backendUrl } = await browser.storage.local.get(["backendUrl"]);
+      if (backendUrl && isOwnBackendUrl(tabUrl, backendUrl)) {
+        showOnly("status-self");
+        return;
+      }
+      if (isCareersIndexUrl(tabUrl)) {
+        showOnly("status-careers-index");
+        return;
+      }
+
+      // Cache-first: previously-scored URLs render instantly. Re-score
+      // button passes `force: true` to bypass.
+      if (!force && isScoreableUrl(tabUrl)) {
+        let cached = await getCachedScore(tabUrl);
+        // Local cache miss — ask the backend before falling through to the
+        // Evaluate button. The backend's `dedupe_key` lookup catches URL
+        // forms the plugin's local cache may have lost (canonicalization
+        // changes, cross-browser, eviction).
+        if (!cached && backendUrl) {
+          cached = await lookupBackendScore(tabUrl, backendUrl);
+          if (cached) {
+            try { await setCachedScore(tabUrl, cached); } catch { /* ignore */ }
+          }
+        }
+        if (cached?.fit) {
+          renderResult(cached.job, cached.fit, cached.usage || {});
+          renderCacheNotice({ timestamp: cached.timestamp });
+          await paintBadgeFromFit(cached.fit);
+          return;
+        }
+      }
+    } catch (err) {
+      console.warn("Pre-score checks failed:", err);
+    }
+
+    // No cached score and the user hasn't asked for one yet — wait for
+    // an explicit click on the "Evaluate this job listing" button. This
+    // prevents the plugin from scoring careers-search pages, marketing
+    // pages, etc. just because they happen to be open when the popup
+    // is invoked. The Re-score button passes `force: true` and skips
+    // this gate.
+    if (!force) {
+      showOnly("status-actions");
+      return;
+    }
+  }
+
+  showOnly("status-loading");
+  try {
+    const { backendUrl } = await loadConfig();
+    let job;
+    if (manualJD) {
+      job = {
+        url: "manual-paste",
+        title: "Manual paste",
+        ats: "unknown",
+        description: manualJD,
+      };
+    } else {
+      const tabUrl = await getActiveTabUrl();
+      if (!isScoreableUrl(tabUrl)) {
+        showOnly("status-empty");
+        return;
+      }
+      job = await extractCurrentTab();
+      // Short-circuit before bothering the backend if the page didn't yield
+      // a plausible JD.
+      if (!job.description || job.description.trim().length < 200) {
+        showOnly("status-empty");
+        return;
+      }
+    }
+
+    const { fit, usage, rankScore } = await scoreViaBackend({ backendUrl, job, force });
+    renderResult(job, fit, usage);
+    renderSaveStatus({
+      cls: "ok",
+      text: `Saved to inbox · rank ${rankScore != null ? rankScore.toFixed(0) : "—"}`,
+    });
+    await paintBadgeFromFit(fit);
+
+    // Local-only cache: avoids a second backend round-trip (and a second
+    // Anthropic call) if the user re-opens the popup on the same URL.
+    // Manual-paste has no stable URL key so setCachedScore no-ops on it.
+    if (!manualJD) {
+      try {
+        await setCachedScore(job.url, { job, fit, usage });
+      } catch (err) {
+        console.warn("Cache write failed:", err);
+      }
+    }
+  } catch (err) {
+    showError(err.message || String(err));
+  }
+}
+
+document.getElementById("error-options").addEventListener("click", () =>
+  browser.runtime.openOptionsPage()
+);
+document.getElementById("error-retry").addEventListener("click", () => run({ force: true }));
+document.getElementById("rescore").addEventListener("click", () => run({ force: true }));
+document.getElementById("score-action").addEventListener("click", () => run({ force: true }));
+
+// ---------------------------------------------------------------------------
+// Watch-this-company bar — shows when the current tab is on a supported ATS
+// and the backend is reachable. Posts to /companies on click, or shows
+// "already watching" if the careers URL is already in /companies.json.
+// ---------------------------------------------------------------------------
+
+async function setupWatchBar() {
+  const bar = $("watch-bar");
+  const btn = $("watch-btn");
+  const status = $("watch-status");
+  bar.hidden = true;
+
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  if (!tab?.url) return;
+
+  const { backendUrl } = await browser.storage.local.get(["backendUrl"]);
+  const backend = (backendUrl || "").replace(/\/$/, "");
+  if (!backend) return;
+  // Suppress the watch bar on the user's own job-store — there's no company
+  // to watch on the inbox itself.
+  if (isOwnBackendUrl(tab.url, backend)) return;
+
+  const careersUrl = deriveCareersUrl(tab.url);
+  if (!careersUrl) return;
+
+  // Best-effort lookup. If the backend's offline we still show the button —
+  // the click handler will surface any failure.
+  let alreadyWatched = false;
+  try {
+    const r = await fetch(`${backend}/companies.json`);
+    if (r.ok) {
+      const list = await r.json();
+      alreadyWatched = list.some((t) => (t.careers_url || "") === careersUrl);
+    }
+  } catch { /* keep button enabled */ }
+
+  bar.hidden = false;
+  status.className = "watch-status";
+  if (alreadyWatched) {
+    btn.textContent = "✓ Watching";
+    btn.classList.add("is-watched");
+    btn.disabled = true;
+    status.textContent = careersUrl.replace(/^https?:\/\//, "");
+    return;
+  }
+
+  btn.textContent = "+ Watch this company";
+  btn.classList.remove("is-watched");
+  btn.disabled = false;
+  status.textContent = careersUrl.replace(/^https?:\/\//, "");
+  btn.onclick = async () => {
+    btn.disabled = true;
+    btn.textContent = "Adding…";
+    try {
+      const body = new URLSearchParams({ careers_url: careersUrl });
+      const r = await fetch(`${backend}/companies`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body,
+        redirect: "manual",
+      });
+      // Flask redirects to /companies on success (302). fetch with redirect:manual
+      // returns response.type === "opaqueredirect" with status 0 — treat as success.
+      const ok = r.ok || r.type === "opaqueredirect" || r.status === 0 || r.status === 302;
+      if (!ok) {
+        const text = await r.text().catch(() => "");
+        throw new Error(text.slice(0, 200) || `HTTP ${r.status}`);
+      }
+      btn.textContent = "✓ Watching";
+      btn.classList.add("is-watched");
+    } catch (err) {
+      btn.disabled = false;
+      btn.textContent = "+ Watch this company";
+      status.className = "watch-status err";
+      status.textContent = `Failed: ${err.message}`;
+    }
+  };
+}
+
+setupWatchBar();
+document.getElementById("manual-score").addEventListener("click", () => {
+  const text = $("manual-jd").value.trim();
+  if (text.length < 100) {
+    showError("Paste at least 100 characters of job description.");
+    return;
+  }
+  run({ manualJD: text });
+});
+
+run();

--- a/job-board/job-store/.gitignore
+++ b/job-board/job-store/.gitignore
@@ -1,0 +1,7 @@
+jobs.db
+jobs.db-shm
+jobs.db-wal
+__pycache__/
+*.pyc
+.venv/
+venv/

--- a/job-board/job-store/README.md
+++ b/job-board/job-store/README.md
@@ -1,0 +1,127 @@
+# job-store
+
+Flask + SQLite backend for the Job Board stack. Serves the inbox UI, runs server-side scoring against Anthropic, holds the `jobs` / `outcomes` / `company_targets` / `settings` tables, and provides the HTTP endpoints the poller and firefox-plugin both call.
+
+The poller (`poller.py`) and the high-priority branch tool (`branch_high_priority.py`) live in this same Python package because they import the backend's `db`, `ranking`, and `urls` modules directly.
+
+## What it does
+
+- **Stores** every discovered job in `jobs.db` (SQLite). Dedupe by `dedupe_key` so the same posting reached via different URL shapes (Greenhouse embed wrapper vs `boards.greenhouse.io` direct) collapses to one row.
+- **Scores** server-side. Both the plugin and the poller POST a description with no `fit_score`; this service calls Anthropic with the resume YAML and the prompt, persists the analysis, returns the score.
+- **Ranks** on read with `fit_score * age_decay(posted_at) * platform_factor(ats)`. Recomputed every request so stale rows naturally drift down without needing a manual rerank pass.
+- **Triages** via the UI at `/`: ranked list, status filters, apply/dismiss/outcome buttons, cleanup-stale button, re-rank-all button.
+- **Manages targets** via `/companies`: company_targets CRUD with per-company deny lists, last_polled timestamps, and an auto-resolve probe for wrapper pages that embed a supported ATS.
+
+## Files
+
+| File | Role |
+|---|---|
+| `app.py` | Flask routes, `detect_ats()`, `probe_embedded_ats()`, the inbox/companies views, cleanup |
+| `db.py` | Schema (`jobs`, `outcomes`, `company_targets`, `settings`), upsert/list helpers |
+| `ranking.py` | Pure functions for `age_decay`, `platform_factor`, `compute_rank_score` |
+| `urls.py` | `canonicalize_url` (storage-canonical) and `compute_dedupe_key` (gh:N, ashby:N, etc.) |
+| `anthropic_client.py` | Resume loading, scoring prompt and schema, the Anthropic API call |
+| `poller.py` | Targeted-company poller CLI (see below) |
+| `branch_high_priority.py` | Bulk-creates branches in the resume repo for jobs above a fit/rank threshold |
+| `csv_import.py` | One-shot CLI to seed `outcomes` from a historical job-hunt CSV |
+| `adapters/{greenhouse,ashby,lever,workday}.py` | Per-ATS `list_jobs(identifier) -> [job, …]` |
+| `templates/index.html` `templates/companies.html` `static/style.css` | Inbox + companies UI |
+| `requirements.txt` | `flask` + `anthropic` |
+
+## Setup
+
+```bash
+cd job-board/job-store
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+export ANTHROPIC_API_KEY=sk-ant-...
+export RESUME_PATH=~/wip/resume/resume_details.yaml
+flask --app app run --port 5000
+```
+
+Open `http://127.0.0.1:5000/`. The DB is created on first run; `jobs.db` is gitignored.
+
+Optional seeding step (historical platform-success stats so the smoothing prior isn't doing all the work):
+
+```bash
+.venv/bin/python csv_import.py path/to/your/job-hunt-outcomes.csv
+```
+
+Only rows flagged `Applied=TRUE` are imported.
+
+## Running the poller
+
+```bash
+.venv/bin/python poller.py --show-locations       # print the location allowlist/denylist
+.venv/bin/python poller.py --target 5 --dry-run   # preview a single target
+.venv/bin/python poller.py                        # poll all targets
+.venv/bin/python poller.py --set-locations "United States,USA,US-,Remote,Americas"
+```
+
+The poller reads `company_targets` and the per-run filter settings, walks each adapter's response newest-first, filters by deny list and location, lazy-fetches descriptions, and POSTs survivors to `/jobs/score`. It stops at the first URL it already has, then moves to the next target.
+
+`--max-new N` caps per-target spend on first polls of big tenants.
+
+## HTTP API
+
+### `POST /jobs/score`
+
+Called by the plugin (extract-and-post) and the poller (after filtering). Body:
+
+```json
+{
+  "url": "https://boards.greenhouse.io/...",
+  "title": "Senior DevOps Engineer",
+  "description": "About the role...",
+  "ats_platform": "greenhouse",
+  "discovered_by": "plugin"
+}
+```
+
+Backend canonicalizes the URL, dedupes via `dedupe_key`, calls Anthropic if the row is new (or `force: true` is set), persists `analysis_json`, returns `{id, fit_score, company, analysis, rank_score, status}`. Legacy callers that already have a `fit_score` and `analysis` skip the Anthropic step.
+
+### `GET /jobs/score?url=<encoded>`
+
+Read-only lookup. Returns the existing score for a URL without spending another Anthropic call. Used by the plugin's toolbar-badge updater.
+
+### `GET /jobs?status={open|applied|closed|all}`
+
+JSON list of jobs in the named view, with live-recomputed ranks.
+
+### `POST /jobs/<id>/{apply,dismiss,outcome}`
+
+Form-encoded. `apply` records the resume-repo branch name; `dismiss` closes the row; `outcome` records `referral`, `callback`, `ghosted`, `rejected`, `offer`, `notes`. Marking `rejected` also auto-closes the row.
+
+### `POST /admin/rerank` `POST /admin/cleanup`
+
+`rerank` recomputes and persists `rank_score` for every row (mostly cosmetic since reads recompute live). `cleanup` deletes age-aged and dead-URL rows in `discovered`/`ranked` status that have no outcome data; threshold via the `cleanup_days_threshold` setting.
+
+### `/companies` `/companies/<id>` `/companies.json`
+
+Companies UI + JSON read. POST `/companies` accepts a careers URL; if it isn't on a supported ATS, the backend fetches it and looks for an embedded Greenhouse/Ashby/Lever/Workday board.
+
+### `GET /resume`
+
+Returns the on-disk resume (content, mtime, sha256). Used by the plugin and as a sanity-check that `RESUME_PATH` resolves.
+
+## Ranking math
+
+```
+rank_score = fit_score * age_decay(posted_at OR discovered_at) * platform_factor(ats)
+
+age_decay(d):
+  days = today - d
+  return clamp(1.0 - days / 45, 0.3, 1.0)
+
+platform_factor(p):
+  smoothed = (callbacks + 2) / (applied + 10)
+  return clamp(0.5 + (smoothed / global_callback_rate) * 0.5, 0.5, 1.5)
+```
+
+Constants live at the top of `ranking.py`. Plan to revisit once you have at least 30 outcomes in the system; until then the smoothing prior dominates per-platform stats.
+
+## Production notes
+
+Single-writer SQLite, `PRAGMA journal_mode = WAL` for read concurrency. Suitable for one-user homelab use. For cluster deployment, see the (planned) Dockerfile and Helm chart issues on the repo.
+
+`flask run` is fine for dev. For something sustained, swap in `gunicorn -w 1 -b 127.0.0.1:5000 app:app` (single worker since SQLite tolerates one writer).

--- a/job-board/job-store/adapters/__init__.py
+++ b/job-board/job-store/adapters/__init__.py
@@ -1,0 +1,20 @@
+"""ATS adapters used by the targeted-company poller.
+
+Each adapter exposes `list_jobs(identifier: dict) -> list[dict]` where every
+returned dict has at least: url, title, description. Optional fields: posted_at.
+
+Adapters do not call the job-store backend or touch the DB. They are pure
+ATS-fetch functions; orchestration lives in poller.py.
+"""
+
+from . import ashby, greenhouse, lever, workday
+
+# `ats_platform` values come from `app.py:detect_ats()` and the plugin's
+# ATS_HOSTS list. Both surfaces standardize on the short slug (ashby, not
+# ashbyhq) so a single dispatch table works for either source.
+ADAPTERS = {
+    "greenhouse": greenhouse,
+    "ashby": ashby,
+    "lever": lever,
+    "workday": workday,
+}

--- a/job-board/job-store/adapters/ashby.py
+++ b/job-board/job-store/adapters/ashby.py
@@ -1,0 +1,70 @@
+"""Ashby list-jobs adapter.
+
+Calls `api.ashbyhq.com/posting-api/job-board/{org}`. The response contains
+plain-text descriptions inline (`descriptionPlain`) so no HTML stripping is
+needed. Per-posting URL is in `jobUrl`.
+
+`identifier` shape: `{"org": "<org-slug>"}`.
+The org slug is the path segment in `jobs.ashbyhq.com/<slug>` URLs.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+API_URL = "https://api.ashbyhq.com/posting-api/job-board/{org}"
+TIMEOUT_SEC = 20
+
+_TAG = re.compile(r"<[^>]+>")
+_WS = re.compile(r"\s+")
+
+
+def _strip_html(s: str) -> str:
+    if not s:
+        return ""
+    no_tags = _TAG.sub(" ", s)
+    decoded = html.unescape(no_tags)
+    return _WS.sub(" ", decoded).strip()
+
+
+def list_jobs(identifier: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return listed postings, newest-first by `publishedAt`."""
+    org = (identifier or {}).get("org")
+    if not org:
+        raise ValueError("ashby identifier missing required 'org' key")
+
+    url = API_URL.format(org=urllib.parse.quote(org, safe=""))
+    req = urllib.request.Request(url, headers={"User-Agent": "job-store-poller/0.1"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+        data = json.load(resp)
+
+    raw = [j for j in (data.get("jobs") or []) if j.get("isListed") is not False]
+    raw.sort(key=lambda j: j.get("publishedAt") or "", reverse=True)
+
+    out: list[dict[str, Any]] = []
+    for job in raw:
+        description = job.get("descriptionPlain") or _strip_html(job.get("descriptionHtml", ""))
+        # Ashby exposes `location` for the primary, plus `secondaryLocations`
+        # (list of strings). Join them so a multi-location posting like
+        # "US-Remote, Dublin, Bengaluru" matches a US-only allowlist.
+        parts = [job.get("location")] + (job.get("secondaryLocations") or [])
+        location = ", ".join([str(p) for p in parts if p])
+        out.append({
+            "url": job.get("jobUrl"),
+            "title": job.get("title"),
+            "description": description,
+            "posted_at": (job.get("publishedAt") or "")[:10] or None,
+            "location": location,
+        })
+    return out
+
+
+def fetch_description(job: dict[str, Any]) -> str:
+    """Ashby returns descriptions inline; no extra fetch needed."""
+    return job.get("description") or ""

--- a/job-board/job-store/adapters/greenhouse.py
+++ b/job-board/job-store/adapters/greenhouse.py
@@ -1,0 +1,71 @@
+"""Greenhouse list-jobs adapter.
+
+Calls the public job-board API (`boards-api.greenhouse.io`) which is the
+canonical source companies expose for embed-based career pages. No auth.
+
+`identifier` shape: `{"board": "<board-token>"}`.
+The board token is the slug from `boards.greenhouse.io/<token>` or the `?for=`
+query param on an embed URL.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import urllib.request
+from typing import Any
+
+
+BOARDS_API = "https://boards-api.greenhouse.io/v1/boards/{board}/jobs?content=true"
+TIMEOUT_SEC = 20
+
+# Strip HTML tags from the Greenhouse `content` field. Greenhouse hosts JDs as
+# HTML; we want plain text for the score prompt. This is intentionally crude —
+# the score model handles whitespace noise fine.
+_TAG = re.compile(r"<[^>]+>")
+_WS = re.compile(r"\s+")
+
+
+def _strip_html(s: str) -> str:
+    if not s:
+        return ""
+    no_tags = _TAG.sub(" ", s)
+    decoded = html.unescape(no_tags)
+    return _WS.sub(" ", decoded).strip()
+
+
+def list_jobs(identifier: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return all current postings for a Greenhouse board, newest-first.
+
+    Sorted on `first_published` (the original publish date) rather than
+    `updated_at` so that a re-edited stale posting doesn't bubble to the top
+    of the list and confuse the poller's stop-when-seen logic.
+    """
+    board = (identifier or {}).get("board")
+    if not board:
+        raise ValueError("greenhouse identifier missing required 'board' key")
+
+    url = BOARDS_API.format(board=urllib.parse.quote(board, safe=""))
+    req = urllib.request.Request(url, headers={"User-Agent": "job-store-poller/0.1"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+        data = json.load(resp)
+
+    raw = data.get("jobs") or []
+    raw.sort(key=lambda j: j.get("first_published") or "", reverse=True)
+
+    out: list[dict[str, Any]] = []
+    for job in raw:
+        out.append({
+            "url": job.get("absolute_url"),
+            "title": job.get("title"),
+            "description": _strip_html(job.get("content", "")),
+            "posted_at": (job.get("first_published") or job.get("updated_at") or "")[:10] or None,
+            "location": (job.get("location") or {}).get("name") or "",
+        })
+    return out
+
+
+def fetch_description(job: dict[str, Any]) -> str:
+    """Greenhouse returns descriptions inline; no extra fetch needed."""
+    return job.get("description") or ""

--- a/job-board/job-store/adapters/lever.py
+++ b/job-board/job-store/adapters/lever.py
@@ -1,0 +1,62 @@
+"""Lever list-jobs adapter.
+
+Calls `api.lever.co/v0/postings/{company}?mode=json`. Returns a top-level
+array (no envelope) of posting objects. Posting URL is in `hostedUrl`.
+
+Lever splits the JD across `descriptionPlain` (the lead paragraph) and
+`descriptionBodyPlain` (the meat). We concatenate both for the scorer.
+
+`identifier` shape: `{"company": "<lever-slug>"}`.
+The slug is the path segment in `jobs.lever.co/<slug>` URLs.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+API_URL = "https://api.lever.co/v0/postings/{company}?mode=json"
+TIMEOUT_SEC = 20
+
+
+def list_jobs(identifier: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return postings newest-first by `createdAt` (epoch ms)."""
+    company = (identifier or {}).get("company")
+    if not company:
+        raise ValueError("lever identifier missing required 'company' key")
+
+    url = API_URL.format(company=urllib.parse.quote(company, safe=""))
+    req = urllib.request.Request(url, headers={"User-Agent": "job-store-poller/0.1"})
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+        data = json.load(resp)
+
+    raw = list(data or [])
+    raw.sort(key=lambda j: j.get("createdAt") or 0, reverse=True)
+
+    out: list[dict[str, Any]] = []
+    for job in raw:
+        parts = [job.get("descriptionPlain", ""), job.get("descriptionBodyPlain", "")]
+        description = "\n\n".join(p for p in parts if p).strip()
+        # createdAt is milliseconds since epoch; turn it into an ISO date.
+        created_ms = job.get("createdAt")
+        posted_at = None
+        if isinstance(created_ms, (int, float)) and created_ms > 0:
+            from datetime import datetime, timezone
+            posted_at = datetime.fromtimestamp(created_ms / 1000, tz=timezone.utc).date().isoformat()
+        cats = job.get("categories") or {}
+        out.append({
+            "url": job.get("hostedUrl"),
+            "title": job.get("text"),
+            "description": description,
+            "posted_at": posted_at,
+            "location": cats.get("location") or job.get("country") or "",
+        })
+    return out
+
+
+def fetch_description(job: dict[str, Any]) -> str:
+    """Lever returns descriptions inline; no extra fetch needed."""
+    return job.get("description") or ""

--- a/job-board/job-store/adapters/workday.py
+++ b/job-board/job-store/adapters/workday.py
@@ -1,0 +1,163 @@
+"""Workday list-jobs adapter.
+
+Workday hosts each tenant's career site on `<tenant>.<region>.myworkdayjobs.com`
+and exposes a JSON API under `/wday/cxs/<tenant>/<site>/`. The list endpoint
+is a POST (not GET), pagination is mandatory, and the JD body lives in a
+per-posting detail endpoint, not the list response.
+
+This is qualitatively more involved than the other adapters — three reasons:
+
+1. List endpoint is POST with a JSON facets body.
+2. Pagination: typical page size is 20; need to walk until total is reached.
+3. Detail fetch per posting to get the JD body.
+
+`identifier` shape (built by `app.py:detect_ats()`):
+    {"host": "<tenant>.<region>.myworkdayjobs.com",
+     "lang": "<lang>",
+     "site": "<site-id>"}
+
+The tenant is the leftmost subdomain of `host`.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+TIMEOUT_SEC = 30
+PAGE_SIZE = 20
+# Safety cap. Workday tenants can have hundreds of openings; a runaway scrape
+# would slow each poll cycle significantly. Each page is one HTTP call; each
+# posting we keep is one detail call. Cap roughly aligns with a 200-posting
+# tenant — past that, the deny list isn't doing its job.
+MAX_PAGES = 10
+
+_TAG = re.compile(r"<[^>]+>")
+_WS = re.compile(r"\s+")
+
+
+def _strip_html(s: str) -> str:
+    if not s:
+        return ""
+    no_tags = _TAG.sub(" ", s)
+    decoded = html.unescape(no_tags)
+    return _WS.sub(" ", decoded).strip()
+
+
+def _http_json(url: str, *, method: str = "GET", body: dict | None = None) -> dict:
+    headers = {
+        "User-Agent": "job-store-poller/0.1",
+        "Accept": "application/json",
+    }
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+        return json.load(resp)
+
+
+def _tenant(host: str) -> str:
+    """Leftmost subdomain of the Workday host."""
+    return host.split(".", 1)[0]
+
+
+def _public_job_url(host: str, lang: str | None, site: str, external_path: str) -> str:
+    """Reconstruct the user-facing URL from list-response fragments."""
+    # external_path begins with "/job/..." per Workday's response shape.
+    segments = [lang, site] if lang else [site]
+    return f"https://{host}/{'/'.join(segments)}{external_path}"
+
+
+def _detail_url(host: str, site: str, external_path: str) -> str:
+    """The detail GET endpoint matching a list-response externalPath."""
+    tenant = _tenant(host)
+    # externalPath is `/job/<loc>/<slug>_<req>`; strip the leading "/job"
+    # because the route already includes `.../job`.
+    if external_path.startswith("/job"):
+        external_path = external_path[len("/job"):]
+    return f"https://{host}/wday/cxs/{tenant}/{urllib.parse.quote(site, safe='')}/job{external_path}"
+
+
+def list_jobs(identifier: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return postings newest-first as lightweight stubs (no description).
+
+    The CXS jobs endpoint defaults to "Most Recent" ordering, so we just
+    preserve the API's order. The JD body lives in the per-posting detail
+    endpoint and is fetched on demand by `fetch_description()` — this lets
+    the poller skip detail fetches for deny-list misses and known URLs.
+    """
+    host = (identifier or {}).get("host")
+    site = (identifier or {}).get("site")
+    lang = (identifier or {}).get("lang")
+    if not host or not site:
+        raise ValueError("workday identifier missing required 'host' / 'site' keys")
+
+    tenant = _tenant(host)
+    list_url = f"https://{host}/wday/cxs/{tenant}/{urllib.parse.quote(site, safe='')}/jobs"
+
+    out: list[dict[str, Any]] = []
+    offset = 0
+    pages = 0
+    while pages < MAX_PAGES:
+        page = _http_json(list_url, method="POST", body={
+            "appliedFacets": {},
+            "limit": PAGE_SIZE,
+            "offset": offset,
+            "searchText": "",
+        })
+        items = page.get("jobPostings") or []
+        if not items:
+            break
+        for p in items:
+            external_path = p.get("externalPath") or ""
+            if not external_path:
+                continue
+            posted = p.get("startDate") or None
+            if isinstance(posted, str) and len(posted) >= 10 and posted[4] == "-":
+                posted = posted[:10]
+            else:
+                # `postedOn` is a human string ("Posted 30+ Days Ago") — not a
+                # date. Drop it; the row's discovered_at takes over downstream.
+                posted = None
+            out.append({
+                "url": _public_job_url(host, lang, site, external_path),
+                "title": p.get("title"),
+                # `description` deliberately omitted — caller pulls via fetch_description.
+                "posted_at": posted,
+                "location": p.get("locationsText") or "",
+                # Private fields used by fetch_description below. Underscore-
+                # prefixed so callers know they're adapter-private.
+                "_host": host,
+                "_site": site,
+                "_external_path": external_path,
+            })
+        total = page.get("total") or 0
+        offset += PAGE_SIZE
+        pages += 1
+        if offset >= total:
+            break
+    return out
+
+
+def fetch_description(job: dict[str, Any]) -> str:
+    """Fetch the JD body for a posting returned by `list_jobs`. Returns
+    empty string on transient failure (the poller skips scoring if the
+    description is too short)."""
+    host = job.get("_host")
+    site = job.get("_site")
+    ext = job.get("_external_path")
+    if not (host and site and ext):
+        return ""
+    try:
+        detail = _http_json(_detail_url(host, site, ext), method="GET")
+    except Exception:
+        return ""
+    info = detail.get("jobPostingInfo") or {}
+    return _strip_html(info.get("jobDescription") or "")

--- a/job-board/job-store/anthropic_client.py
+++ b/job-board/job-store/anthropic_client.py
@@ -1,0 +1,226 @@
+"""Server-side Anthropic scoring for job-store.
+
+Mirrors the prompt and schema used by `firefox-plugin/popup.js` so plugin-mode
+and poller-mode scoring stay aligned. The plugin keeps calling Anthropic
+directly for now (`fit_score` is in the POST payload); when a caller omits
+`fit_score`, `app.py` falls through to `score_job()` here.
+
+Configuration (env vars):
+- ANTHROPIC_API_KEY (required)
+- ANTHROPIC_MODEL (optional; defaults to claude-haiku-4-5)
+- RESUME_PATH (optional; defaults to ../resume_details.yaml relative to this file)
+- GROWTH_KEYWORDS (optional; comma-separated career-growth keywords)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    from anthropic import Anthropic
+except ImportError as e:
+    raise ImportError(
+        "The `anthropic` package is required for server-side scoring. "
+        "Run `pip install -r requirements.txt` to install it."
+    ) from e
+
+
+MODEL = os.environ.get("ANTHROPIC_MODEL", "claude-haiku-4-5")
+MAX_DESCRIPTION_CHARS = 12000
+
+# Schema kept in lockstep with `firefox-plugin/popup.js`'s FIT_SCHEMA. Edit
+# both files together when the prompt or output shape changes.
+FIT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "candidate_score": {
+            "type": "integer",
+            "description": "A score between 1 and 100 inclusive for how well the resume matches the job description.",
+        },
+        "career_growth_score": {
+            "type": "integer",
+            "description": "A score between 1 and 100 inclusive for words in the job description that are similar to the career-growth keywords provided.",
+        },
+        "candidate_explanation": {
+            "type": "string",
+            "description": "An explanation of candidate_score, no longer than 250 words.",
+        },
+        "candidate_strengths": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Strengths in the resume that the candidate possesses.",
+        },
+        "candidate_deficiencies": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Deficiencies in the resume that the candidate likely possesses, but could be better highlighted.",
+        },
+        "job_description_score": {
+            "type": "integer",
+            "description": "A score between 1 and 100 inclusive for how well the job description is written.",
+        },
+        "job_company_name": {
+            "type": "string",
+            "description": "From the job description, identify the company name.",
+        },
+    },
+    "required": [
+        "candidate_score", "career_growth_score", "candidate_explanation",
+        "candidate_strengths", "candidate_deficiencies",
+        "job_description_score", "job_company_name",
+    ],
+    "additionalProperties": False,
+}
+
+SYSTEM_INSTRUCTIONS = (
+    "Act as an expert technical recruiter with a previous career in software engineering "
+    "who can critically compare resumes to job descriptions to determine if a candidate is a fit for a role."
+)
+
+
+def _resume_path() -> Path:
+    override = os.environ.get("RESUME_PATH")
+    if not override:
+        raise RuntimeError(
+            "RESUME_PATH is not set. Point it at your resume YAML, "
+            "e.g. RESUME_PATH=~/wip/resume/resume_details.yaml"
+        )
+    return Path(override).expanduser()
+
+
+def read_resume() -> dict[str, Any]:
+    """Read resume_details.yaml from disk. Re-read per call by design: the
+    file is small and reads are local, so simplicity wins over caching."""
+    path = _resume_path()
+    if not path.exists():
+        raise FileNotFoundError(
+            f"resume file not found: {path}. Set RESUME_PATH if it lives elsewhere."
+        )
+    content = path.read_text(encoding="utf-8")
+    stat = path.stat()
+    return {
+        "content": content,
+        "path": str(path),
+        "mtime": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+        "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    }
+
+
+def _client() -> Anthropic:
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY is not set. Server-side scoring requires it."
+        )
+    return Anthropic(api_key=key)
+
+
+def _format_user_message(*, description: str, url: str | None,
+                         title: str | None, ats_platform: str | None,
+                         growth_keywords: str) -> str:
+    description = (description or "")[:MAX_DESCRIPTION_CHARS]
+    keywords_line = (
+        f"- career_growth_score: a score between 1 and 100 for words in the "
+        f"job description that are similar to the following: {growth_keywords}"
+        if growth_keywords
+        else "- career_growth_score: a score between 1 and 100 for words in "
+             "the job description that suggest meaningful career growth for "
+             "a senior infrastructure / build-and-release engineer."
+    )
+    instruction = "\n".join([
+        "Compare the resume and job description with the goal of helping the candidate tailor their resume for the position.",
+        "Provide a JSON formatted response containing the following key/value pairs:",
+        "- candidate_score: a score between 1 and 100 for how well the resume matches the job description.",
+        keywords_line,
+        "- candidate_explanation: an explanation of the score no longer than 250 words.",
+        "- candidate_deficiencies: a list of deficiencies in the resume that the candidate likely possesses, but could be better highlighted in the resume.",
+        "- candidate_strengths: a list of strengths in the resume that the candidate possesses.",
+        "- job_description_score: a score between 1 and 100 for how well the job description is written.",
+        "- job_company_name: from the job description, identify the company name.",
+        "",
+        "The JSON should be valid, parsable, and contain no additional formatting or comments.",
+    ])
+    return (
+        f"{instruction}\n\n"
+        f"<job_posting>\n"
+        f"URL: {url or 'n/a'}\n"
+        f"Title: {title or 'n/a'}\n"
+        f"ATS Platform: {ats_platform or 'unknown'}\n"
+        f"Description:\n{description}\n"
+        f"</job_posting>"
+    )
+
+
+def score_job(*, description: str, url: str | None = None,
+              title: str | None = None,
+              ats_platform: str | None = None) -> dict[str, Any]:
+    """Score a JD against the on-disk resume. Returns {fit, usage, model}.
+
+    Raises ValueError if the description is too short, RuntimeError if the
+    response can't be parsed, FileNotFoundError if the resume is missing.
+    """
+    if not description or len(description) < 100:
+        raise ValueError("description is empty or too short to score (< 100 chars).")
+
+    resume = read_resume()["content"]
+    growth_keywords = os.environ.get("GROWTH_KEYWORDS", "").strip()
+
+    # output_config is the structured-outputs parameter; it's not in every
+    # version of the SDK as a named kwarg, so route it via extra_body for
+    # forward-compat.
+    response = _client().messages.create(
+        model=MODEL,
+        max_tokens=2048,
+        temperature=0,
+        system=[
+            {"type": "text", "text": SYSTEM_INSTRUCTIONS},
+            {
+                "type": "text",
+                "text": f"The candidate's resume is below.\n\n<resume>\n{resume}\n</resume>",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        messages=[
+            {
+                "role": "user",
+                "content": _format_user_message(
+                    description=description, url=url, title=title,
+                    ats_platform=ats_platform, growth_keywords=growth_keywords,
+                ),
+            }
+        ],
+        extra_body={
+            "output_config": {
+                "format": {"type": "json_schema", "schema": FIT_SCHEMA}
+            }
+        },
+    )
+
+    text_block = next(
+        (b.text for b in response.content if getattr(b, "type", None) == "text"),
+        None,
+    )
+    if not text_block:
+        raise RuntimeError("Anthropic response contained no text block.")
+
+    try:
+        fit = json.loads(text_block)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Anthropic response was not valid JSON: {e}") from e
+
+    usage = getattr(response, "usage", None)
+    return {
+        "fit": fit,
+        "usage": {
+            "input_tokens": getattr(usage, "input_tokens", 0),
+            "output_tokens": getattr(usage, "output_tokens", 0),
+            "cache_read_input_tokens": getattr(usage, "cache_read_input_tokens", 0),
+            "cache_creation_input_tokens": getattr(usage, "cache_creation_input_tokens", 0),
+        },
+        "model": MODEL,
+    }

--- a/job-board/job-store/app.py
+++ b/job-board/job-store/app.py
@@ -1,0 +1,742 @@
+"""
+Job-store backend.
+
+Run for development:
+
+    pip install -r requirements.txt
+    flask --app app run --port 5000
+
+The Firefox plugin posts scored jobs to /jobs/score; humans triage them via
+the ranked list at /.
+"""
+
+import json
+import re
+from datetime import datetime, date, timedelta
+
+from flask import (Flask, abort, jsonify, redirect, render_template, request,
+                   url_for)
+
+import db
+import ranking
+from urls import canonicalize_url
+
+
+app = Flask(__name__)
+db.init_db()
+
+
+# ---------------------------------------------------------------------------
+# ATS auto-detection — maps a careers URL to (platform, identifier dict).
+# Identifier shape is platform-specific; the bot will use these fields to
+# build the correct list-jobs API call.
+# ---------------------------------------------------------------------------
+
+def _workday_extract(m):
+    """Workday tenants come in two URL shapes:
+       /<lang>/<site>  (NVIDIA: /en-US/NVIDIAExternalCareerSite)
+       /<site>         (Red Hat: /jobs, Autodesk: /Ext, Intel: /External)
+    Treat the trailing segment as the site in both cases."""
+    first = m.group("first")
+    second = m.group("second")
+    if second:
+        return {"host": m.group("host"), "lang": first, "site": second}
+    return {"host": m.group("host"), "site": first}
+
+
+ATS_DETECTORS = [
+    (
+        re.compile(r"(?:job-)?boards\.greenhouse\.io/(?:embed/job_board/[^/?#]+/jobs\?for=)?([^/?#]+)"),
+        "greenhouse",
+        lambda m: {"board": m.group(1)},
+    ),
+    (re.compile(r"jobs\.lever\.co/([^/?#]+)"), "lever",
+     lambda m: {"company": m.group(1)}),
+    (re.compile(r"jobs\.ashbyhq\.com/([^/?#]+)"), "ashby",
+     lambda m: {"org": m.group(1)}),
+    (re.compile(
+        r"(?P<host>[a-z0-9-]+\.[a-z0-9-]+\.myworkdayjobs\.com)"
+        r"/(?P<first>[^/?#]+)(?:/(?P<second>[^/?#]+))?"
+     ),
+     "workday",
+     _workday_extract),
+]
+
+
+def detect_ats(careers_url):
+    """Return (ats_platform, identifier_dict). Falls back to ('other', {})."""
+    for pattern, platform, extractor in ATS_DETECTORS:
+        m = pattern.search(careers_url)
+        if m:
+            return platform, extractor(m)
+    return "other", {}
+
+
+# Regex patterns used to find an embedded ATS on a non-ATS careers page.
+# Order matters: greenhouse-embed marker first because it's the unambiguous
+# signal (board token in querystring).
+EMBED_PROBES = [
+    (re.compile(r"boards\.greenhouse\.io/embed/job_board/js\?for=([^\"'&]+)"),
+     lambda m: ("greenhouse", f"https://boards.greenhouse.io/{m.group(1)}")),
+    (re.compile(r"(?:job-)?boards\.greenhouse\.io/([a-z0-9_-]+)/jobs"),
+     lambda m: ("greenhouse", f"https://boards.greenhouse.io/{m.group(1)}")),
+    (re.compile(r"jobs\.ashbyhq\.com/([a-z0-9_-]+)"),
+     lambda m: ("ashby", f"https://jobs.ashbyhq.com/{m.group(1)}")),
+    (re.compile(r"jobs\.lever\.co/([a-z0-9_-]+)"),
+     lambda m: ("lever", f"https://jobs.lever.co/{m.group(1)}")),
+    (re.compile(r"([a-z0-9-]+\.[a-z0-9-]+\.myworkdayjobs\.com)/([^/\"']+)/([^/?#\"']+)"),
+     lambda m: ("workday", f"https://{m.group(1)}/{m.group(2)}/{m.group(3)}")),
+]
+
+
+def probe_embedded_ats(careers_url, timeout=8):
+    """Fetch the careers URL and scan for an embedded supported ATS.
+
+    Returns (resolved_url, ats_platform) if found, else None. Useful when a
+    company's careers page is a wrapper (e.g. company.com/careers) that
+    embeds a Greenhouse board via the standard <script> tag — we'd rather
+    extract the canonical URL than reject the input outright.
+    """
+    import urllib.request
+    req = urllib.request.Request(
+        careers_url,
+        headers={"User-Agent": "Mozilla/5.0 (compatible; job-store/0.1)"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read(500_000).decode("utf-8", errors="replace")
+    except Exception:
+        return None
+    for pattern, resolver in EMBED_PROBES:
+        m = pattern.search(body)
+        if m:
+            platform, resolved = resolver(m)
+            return resolved, platform
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Page rendering helpers
+# ---------------------------------------------------------------------------
+
+def _age_label(posted_at, discovered_at):
+    """Human-readable age string for the row."""
+    target = posted_at or discovered_at
+    if not target:
+        return "—"
+    if isinstance(target, str):
+        try:
+            target = datetime.fromisoformat(target[:19].replace("T", " "))
+        except ValueError:
+            try:
+                target = datetime.combine(date.fromisoformat(target[:10]),
+                                          datetime.min.time())
+            except ValueError:
+                return "—"
+    if isinstance(target, date) and not isinstance(target, datetime):
+        target = datetime.combine(target, datetime.min.time())
+    days = (datetime.now() - target).days
+    prefix = "discovered" if posted_at is None else "posted"
+    if days <= 0:
+        return f"{prefix} today"
+    if days == 1:
+        return f"{prefix} 1 day ago"
+    if days < 30:
+        return f"{prefix} {days} days ago"
+    if days < 90:
+        return f"{prefix} {days // 7}w ago"
+    return f"{prefix} {days // 30}mo ago"
+
+
+def _derive_recommendation(fit_score):
+    """Map a 1-100 fit_score into the recommendation bucket the UI styles by.
+    Matches the client-side derivation in firefox-plugin/popup.js."""
+    if fit_score is None:
+        return None
+    if fit_score >= 80:
+        return "strong_match"
+    if fit_score >= 60:
+        return "consider"
+    if fit_score >= 40:
+        return "weak_match"
+    return "skip"
+
+
+def _normalize_analysis(analysis):
+    """Tolerant adapter: accepts either the old plugin shape (summary,
+    strengths, gaps, recommendation) or the new Gemini-aligned shape
+    (candidate_explanation, candidate_strengths, candidate_deficiencies)
+    and returns the keys the templates expect."""
+    return {
+        "summary": analysis.get("candidate_explanation") or analysis.get("summary") or "",
+        "strengths": analysis.get("candidate_strengths") or analysis.get("strengths") or [],
+        "gaps": analysis.get("candidate_deficiencies") or analysis.get("gaps") or [],
+        "recommendation": analysis.get("recommendation"),
+    }
+
+
+def _decorate(job):
+    """Add derived fields the template needs without round-tripping JSON in Jinja."""
+    analysis = db.parse_analysis(job.get("analysis_json"))
+    normalized = _normalize_analysis(analysis)
+    job["summary"] = normalized["summary"]
+    job["recommendation"] = (
+        normalized["recommendation"] or _derive_recommendation(job.get("fit_score"))
+    )
+    job["strengths"] = normalized["strengths"]
+    job["gaps"] = normalized["gaps"]
+    job["age_label"] = _age_label(job.get("posted_at"), job.get("discovered_at"))
+    return job
+
+
+def _with_live_rank(jobs):
+    """Overwrite each job's `rank_score` with a freshly-computed value so
+    older listings drift down naturally without needing a /admin/rerank pass.
+    Platform stats are computed once per ATS per request so a 500-row inbox
+    is N+1 queries (one per ATS), not 2N.
+    """
+    platform_cache = {}
+    for job in jobs:
+        ats = job.get("ats_platform")
+        if ats not in platform_cache:
+            platform_cache[ats] = db.get_platform_stats(ats)
+        job["rank_score"] = ranking.compute_rank_score(
+            job.get("fit_score"),
+            job.get("posted_at"),
+            platform_cache[ats],
+            discovered_at=job.get("discovered_at"),
+        )
+    return jobs
+
+
+def _slug(value):
+    return re.sub(r"[^a-z0-9]+", "", (value or "").lower()) or "unknown"
+
+
+def _generate_branch_name(job):
+    """Match the existing convention: `companyName-YYYYMMDD`."""
+    company = _slug(job.get("company"))
+    return f"{company}-{datetime.utcnow().strftime('%Y%m%d')}"
+
+
+# ---------------------------------------------------------------------------
+# Routes — UI
+# ---------------------------------------------------------------------------
+
+@app.route("/")
+def index():
+    status = request.args.get("status", "open")
+    # `rank_score` is now computed at read time (see `_with_live_rank`) so
+    # there's no point sorting by the stored column in SQL — pull rows in an
+    # arbitrary stable order, then sort in Python after recomputing.
+    if status == "open":
+        jobs = db.list_jobs(statuses=["discovered", "ranked"], order="id DESC")
+    elif status == "applied":
+        jobs = db.list_jobs(statuses=["applied"], order="applied_at DESC")
+    elif status == "closed":
+        jobs = db.list_jobs(statuses=["closed"], order="discovered_at DESC")
+    else:
+        jobs = db.list_jobs(order="id DESC")
+
+    if status in ("open", "all", "applied"):
+        # Applied jobs we also live-recompute, so the user sees how stale a
+        # waiting application is. Closed rows keep their stored rank — they
+        # aren't sort keys for that view anyway.
+        jobs = _with_live_rank(jobs)
+        if status == "open":
+            jobs.sort(
+                key=lambda j: (
+                    -(j.get("rank_score") if j.get("rank_score") is not None else -1),
+                    -(j.get("fit_score") or 0),
+                ),
+            )
+
+    cleanup_days = int(db.get_setting(CLEANUP_DAYS_KEY) or DEFAULT_CLEANUP_DAYS)
+    # Encoded by /admin/cleanup as "age,dead,total" so we can render a
+    # one-line summary without needing a session/flash mechanism.
+    cleanup_summary = None
+    raw = request.args.get("cleanup")
+    if raw:
+        try:
+            age, dead, total = (int(x) for x in raw.split(","))
+            cleanup_summary = {"age": age, "dead": dead, "total": total}
+        except (ValueError, TypeError):
+            pass
+
+    return render_template(
+        "index.html",
+        jobs=[_decorate(j) for j in jobs],
+        counts=db.status_counts(),
+        stats=db.platform_stats_summary(),
+        filter_status=status,
+        cleanup_days=cleanup_days,
+        cleanup_summary=cleanup_summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routes — JSON ingest
+# ---------------------------------------------------------------------------
+
+@app.route("/jobs/score", methods=["GET", "POST", "OPTIONS"])
+def score_job():
+    if request.method == "OPTIONS":
+        return ("", 204)
+
+    # GET path: read-only lookup used by the toolbar badge to surface the
+    # existing score for a URL without provoking another Anthropic call. The
+    # plugin's local cache is the fast path; this is the fallback when the
+    # cache is cold (different browser, after a clear, post-canonicalization).
+    if request.method == "GET":
+        raw = (request.args.get("url") or "").strip()
+        if not raw:
+            return jsonify({"error": "url is required"}), 400
+        lookup_url = canonicalize_url(raw)
+        existing = db.get_job_by_url(lookup_url)
+        if not existing or existing.get("fit_score") is None:
+            return jsonify({"error": "not scored"}), 404
+        stats = db.get_platform_stats(existing.get("ats_platform"))
+        live_rank = ranking.compute_rank_score(
+            existing["fit_score"], existing.get("posted_at"), stats,
+            discovered_at=existing.get("discovered_at"),
+        )
+        return jsonify({
+            "id": existing["id"],
+            "rank_score": live_rank,
+            "status": existing.get("status"),
+            "fit_score": existing["fit_score"],
+            "company": existing.get("company"),
+            "analysis": db.parse_analysis(existing.get("analysis_json")),
+        }), 200
+
+    payload = request.get_json(silent=True) or {}
+    url = (payload.get("url") or "").strip()
+    if not url:
+        return jsonify({"error": "url is required"}), 400
+
+    # Manual pastes from the plugin all use a constant URL — make each one
+    # unique server-side so we don't overwrite each other.
+    if url.startswith("manual-paste"):
+        url = f"manual-paste-{datetime.utcnow().strftime('%Y%m%d%H%M%S%f')}"
+    else:
+        # Normalize so the plugin's browser-tab URL and the poller's API
+        # URL converge to one row (no trailing-slash / tracking-param drift).
+        url = canonicalize_url(url)
+
+    fit_score = payload.get("fit_score")
+    analysis = payload.get("analysis")
+    posted_at = payload.get("posted_at")
+    description = payload.get("description")
+    company = payload.get("company")
+    force = bool(payload.get("force"))
+
+    # Dedupe: if we've already scored this canonical URL, return the existing
+    # analysis without spending another Anthropic call. The plugin's local
+    # cache used to handle this client-side, but URL canonicalization
+    # invalidated old cache entries; this guard catches any pre-existing row
+    # for the canonical URL regardless of which surface discovered it first.
+    # The Re-score button passes `force: true` to override.
+    if fit_score is None and not force:
+        existing = db.get_job_by_url(url)
+        if existing and existing.get("fit_score") is not None:
+            cached_analysis = db.parse_analysis(existing.get("analysis_json"))
+            stats = db.get_platform_stats(existing.get("ats_platform"))
+            live_rank = ranking.compute_rank_score(
+                existing["fit_score"], existing.get("posted_at"), stats,
+                discovered_at=existing.get("discovered_at"),
+            )
+            return jsonify({
+                "id": existing["id"],
+                "rank_score": live_rank,
+                "status": existing.get("status"),
+                "fit_score": existing["fit_score"],
+                "company": existing.get("company"),
+                "analysis": cached_analysis,
+                "cached": True,
+            }), 200
+
+    # Server-side scoring path: caller (e.g. the poller) didn't compute a
+    # score, but did send a JD. Run it through Anthropic here. The plugin
+    # currently still scores client-side and sends fit_score+analysis, so it
+    # bypasses this branch — letting the migration to server-side scoring
+    # happen incrementally per SERVER_SIDE_SCORING.md.
+    usage_meta = None
+    if fit_score is None and description and len(description) >= 100:
+        try:
+            from anthropic_client import score_job as _score_job
+            result = _score_job(
+                description=description,
+                url=url,
+                title=payload.get("title"),
+                ats_platform=payload.get("ats_platform"),
+            )
+            analysis = result["fit"]
+            fit_score = analysis.get("candidate_score")
+            company = company or analysis.get("job_company_name")
+            usage_meta = result["usage"]
+        except Exception as err:
+            return jsonify({"error": f"scoring failed: {err}"}), 502
+
+    job_id = db.upsert_job(
+        url=url,
+        company=company,
+        title=payload.get("title"),
+        description=description,
+        ats_platform=payload.get("ats_platform"),
+        posted_at=posted_at,
+        discovered_by=payload.get("discovered_by", "plugin"),
+        fit_score=fit_score,
+        analysis_json=json.dumps(analysis) if analysis else None,
+    )
+
+    rank = ranking.compute_rank_score(
+        fit_score, posted_at,
+        db.get_platform_stats(payload.get("ats_platform")),
+        discovered_at=datetime.utcnow().isoformat(),
+    )
+    new_status = "ranked" if fit_score is not None else "discovered"
+    db.update_rank_score(job_id, rank, status=new_status)
+
+    response_body = {
+        "id": job_id,
+        "rank_score": rank,
+        "status": new_status,
+        "fit_score": fit_score,
+        "company": company,
+        "analysis": analysis,
+    }
+    if usage_meta is not None:
+        response_body["usage"] = usage_meta
+    return jsonify(response_body), 200
+
+
+@app.route("/resume", methods=["GET"])
+def get_resume():
+    """Return the on-disk resume contents. Used by the plugin (eventually) to
+    bootstrap or refresh its cached copy, and useful for sanity-checking which
+    resume file the backend will feed to Anthropic during scoring."""
+    try:
+        from anthropic_client import read_resume
+        return jsonify(read_resume())
+    except FileNotFoundError as err:
+        return jsonify({"error": str(err)}), 404
+    except Exception as err:
+        return jsonify({"error": str(err)}), 500
+
+
+@app.route("/jobs", methods=["GET"])
+def list_jobs_json():
+    # Mirror the UI's status filter: "open" is a logical state, not a row
+    # value, so expand it to ['discovered', 'ranked'] like the index route
+    # does. "all" / unset → no filter.
+    status = request.args.get("status")
+    if status in (None, "", "all"):
+        statuses = None
+    elif status == "open":
+        statuses = ["discovered", "ranked"]
+    else:
+        statuses = [status]
+    # Pull in stable order then re-rank live so consumers see fresh scores.
+    jobs = db.list_jobs(statuses=statuses, order="id DESC")
+    jobs = _with_live_rank(jobs)
+    jobs.sort(
+        key=lambda j: -(j.get("rank_score") if j.get("rank_score") is not None else -1),
+    )
+    return jsonify([_decorate(j) for j in jobs])
+
+
+# ---------------------------------------------------------------------------
+# Routes — actions (form-encoded, redirect back to /)
+# ---------------------------------------------------------------------------
+
+@app.route("/jobs/<int:job_id>/apply", methods=["POST"])
+def apply_job(job_id):
+    row = db.get_job(job_id)
+    if not row:
+        abort(404)
+    branch = (request.form.get("branch") or "").strip() or _generate_branch_name(dict(row))
+    db.mark_applied(job_id, branch)
+    db.upsert_outcome(job_id)  # ensure outcomes row exists
+    return redirect(url_for("index", status="applied"))
+
+
+@app.route("/jobs/<int:job_id>/dismiss", methods=["POST"])
+def dismiss_job(job_id):
+    db.update_status(job_id, "closed")
+    return redirect(url_for("index", status=request.args.get("status", "open")))
+
+
+@app.route("/jobs/<int:job_id>/outcome", methods=["POST"])
+def record_outcome(job_id):
+    rejected = bool(request.form.get("rejected"))
+    db.upsert_outcome(
+        job_id,
+        referral=bool(request.form.get("referral")),
+        callback=bool(request.form.get("callback")),
+        callback_at=request.form.get("callback_at") or None,
+        ghosted=bool(request.form.get("ghosted")),
+        rejected=rejected,
+        offer=bool(request.form.get("offer")),
+        notes=(request.form.get("notes") or "").strip(),
+    )
+    # A rejection is a terminal state; auto-close so it leaves the applied
+    # list without the user having to click Dismiss separately. The outcome
+    # row stays intact (cascade-protected), so historical stats are kept.
+    if rejected:
+        db.update_status(job_id, "closed")
+    return redirect(url_for("index", status="applied"))
+
+
+CLEANUP_DAYS_KEY = "cleanup_days_threshold"
+DEFAULT_CLEANUP_DAYS = 35
+
+# Reasonable parallelism for the URL-liveness sweep. Most ATSes respond within
+# a second; 10 in flight keeps the cleanup snappy without hammering any one
+# host (each posting is on a distinct domain/board in practice).
+LIVENESS_WORKERS = 10
+LIVENESS_TIMEOUT = 8
+
+
+def is_url_dead(url):
+    """Return True only when the URL clearly resolves to 404 / 410. Network
+    errors, timeouts, and other non-success statuses return False — we'd
+    rather keep a live job around as 'maybe alive' than delete on noise."""
+    import urllib.error
+    import urllib.request
+    if not url or url.startswith("manual-paste"):
+        return False
+    headers = {"User-Agent": "Mozilla/5.0 (compatible; job-store-cleanup/0.1)"}
+    # Try HEAD first; many servers reject HEAD (405) so fall back to GET.
+    for method in ("HEAD", "GET"):
+        try:
+            req = urllib.request.Request(url, method=method, headers=headers)
+            with urllib.request.urlopen(req, timeout=LIVENESS_TIMEOUT):
+                return False
+        except urllib.error.HTTPError as err:
+            if err.code in (404, 410):
+                return True
+            if err.code == 405 and method == "HEAD":
+                continue
+            return False
+        except Exception:
+            return False
+    return False
+
+
+def _parse_discovered_at(value):
+    """Best-effort parse of `jobs.discovered_at` (SQLite stores as TEXT)."""
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value).replace(" ", "T"))
+    except ValueError:
+        return None
+
+
+@app.route("/admin/cleanup", methods=["POST"])
+def cleanup_stale():
+    # Days threshold — form override if provided, otherwise the saved setting,
+    # otherwise the default. Persist whatever was used so the input keeps the
+    # last value next time the user opens the inbox.
+    raw_days = (request.form.get("days") or "").strip()
+    if raw_days:
+        try:
+            days = max(1, min(365, int(raw_days)))
+        except ValueError:
+            days = int(db.get_setting(CLEANUP_DAYS_KEY) or DEFAULT_CLEANUP_DAYS)
+    else:
+        days = int(db.get_setting(CLEANUP_DAYS_KEY) or DEFAULT_CLEANUP_DAYS)
+    db.set_setting(CLEANUP_DAYS_KEY, days)
+
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    candidates = db.list_cleanup_candidates()
+
+    age_stale_ids = []
+    liveness_targets = []
+    for row in candidates:
+        discovered = _parse_discovered_at(row.get("discovered_at"))
+        if discovered and discovered < cutoff:
+            age_stale_ids.append(row["id"])
+        else:
+            liveness_targets.append(row)
+
+    # Liveness sweep in parallel — bounded by LIVENESS_WORKERS so we don't
+    # spawn a thread per candidate on a 500-row DB.
+    dead_ids = []
+    if liveness_targets:
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=LIVENESS_WORKERS) as pool:
+            futures = {pool.submit(is_url_dead, r["url"]): r["id"] for r in liveness_targets}
+            for fut, jid in futures.items():
+                try:
+                    if fut.result():
+                        dead_ids.append(jid)
+                except Exception:
+                    pass
+
+    to_delete = set(age_stale_ids) | set(dead_ids)
+    deleted = db.delete_jobs(list(to_delete))
+
+    return redirect(url_for(
+        "index",
+        status=request.form.get("status", "open"),
+        cleanup=f"{len(age_stale_ids)},{len(dead_ids)},{deleted}",
+    ))
+
+
+@app.route("/admin/rerank", methods=["POST"])
+def rerank_all():
+    """Recompute rank_score for every job. Cheap; safe to run any time.
+    Mostly cosmetic now that the inbox reads rank live, but useful for any
+    external SQL consumer that queries `rank_score` directly."""
+    for job in db.all_jobs_for_rerank():
+        rank = ranking.compute_rank_score(
+            job["fit_score"], job["posted_at"],
+            db.get_platform_stats(job["ats_platform"]),
+            discovered_at=job.get("discovered_at"),
+        )
+        db.update_rank_score(job["id"], rank)
+    return redirect(url_for("index"))
+
+
+# ---------------------------------------------------------------------------
+# Routes — targeted companies (config for the discovery bot)
+# ---------------------------------------------------------------------------
+
+def _decorate_target(target):
+    """Add derived fields the template needs."""
+    target = db.parse_company_target(target)
+    target["last_polled_label"] = _age_label(None, target.get("last_polled_at"))
+    return target
+
+
+def _infer_name_from_identifier(careers_url, ats_platform, identifier):
+    """Best-effort default name when the user doesn't provide one."""
+    if not identifier:
+        # Fall back to the URL's hostname
+        m = re.search(r"https?://([^/]+)", careers_url)
+        return (m.group(1) if m else "Unnamed").split(".")[0].capitalize()
+    for key in ("board", "company", "org"):
+        if identifier.get(key):
+            return identifier[key].replace("-", " ").replace("_", " ").title()
+    if ats_platform == "workday" and identifier.get("host"):
+        return identifier["host"].split(".")[0].capitalize()
+    return "Unnamed"
+
+
+def _render_companies(add_error=None, add_url="", add_name="", status=200):
+    targets = [_decorate_target(t) for t in db.list_company_targets()]
+    return (
+        render_template(
+            "companies.html",
+            targets=targets,
+            add_error=add_error,
+            add_url=add_url,
+            add_name=add_name,
+        ),
+        status,
+    )
+
+
+SUPPORTED_ATSES = ("Greenhouse", "Ashby", "Lever", "Workday")
+
+
+@app.route("/companies", methods=["GET"])
+def companies_index():
+    return _render_companies()
+
+
+@app.route("/companies", methods=["POST"])
+def create_company():
+    careers_url = (request.form.get("careers_url") or "").strip()
+    name = (request.form.get("name") or "").strip()
+    if not careers_url:
+        return _render_companies(
+            add_error="Careers URL is required.",
+            add_url=careers_url, add_name=name, status=400,
+        )
+
+    ats_platform, identifier = detect_ats(careers_url)
+
+    # If the URL itself doesn't match a known ATS, fetch it and see if it
+    # *embeds* one. This catches the common case where a user pastes a
+    # wrapper page like https://www.company.com/careers/ that pulls in a
+    # Greenhouse board via the standard embed script.
+    if ats_platform == "other":
+        probe = probe_embedded_ats(careers_url)
+        if probe is not None:
+            resolved_url, _ = probe
+            ats_platform, identifier = detect_ats(resolved_url)
+            careers_url = resolved_url  # store the canonical URL
+        else:
+            supported = ", ".join(SUPPORTED_ATSES)
+            return _render_companies(
+                add_error=(
+                    f"{careers_url} isn't on a supported ATS and doesn't embed one. "
+                    f"The poller only knows how to talk to {supported}. "
+                    f"Try a direct job-board URL — e.g., "
+                    f"https://boards.greenhouse.io/<board>, "
+                    f"https://jobs.ashbyhq.com/<org>, "
+                    f"https://jobs.lever.co/<company>, or "
+                    f"https://<tenant>.<region>.myworkdayjobs.com/<lang>/<site>."
+                ),
+                add_url=careers_url, add_name=name, status=400,
+            )
+
+    if not name:
+        name = _infer_name_from_identifier(careers_url, ats_platform, identifier)
+    try:
+        db.create_company_target(
+            name=name,
+            careers_url=careers_url,
+            ats_platform=ats_platform,
+            ats_identifier=identifier,
+        )
+    except Exception as err:
+        # Most likely a UNIQUE constraint violation on careers_url
+        return _render_companies(
+            add_error=f"Could not add company: {err}",
+            add_url=careers_url, add_name=name, status=400,
+        )
+    return redirect(url_for("companies_index"))
+
+
+@app.route("/companies/<int:target_id>", methods=["POST"])
+def update_company(target_id):
+    if not db.get_company_target(target_id):
+        abort(404)
+    name = (request.form.get("name") or "").strip() or None
+    deny_text = request.form.get("deny_list", "")
+    deny_list = [line.strip() for line in deny_text.splitlines() if line.strip()]
+    db.update_company_target(target_id, name=name, deny_list=deny_list)
+    return redirect(url_for("companies_index"))
+
+
+@app.route("/companies/<int:target_id>/delete", methods=["POST"])
+def delete_company(target_id):
+    db.delete_company_target(target_id)
+    return redirect(url_for("companies_index"))
+
+
+@app.route("/companies.json", methods=["GET"])
+def companies_json():
+    """Bot reads this to know which companies to poll and how to filter."""
+    return jsonify([_decorate_target(t) for t in db.list_company_targets()])
+
+
+# ---------------------------------------------------------------------------
+# CORS — allow the Firefox plugin (moz-extension://...) to POST.
+# ---------------------------------------------------------------------------
+
+@app.after_request
+def cors(response):
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+    response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    return response
+
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5000, debug=True)

--- a/job-board/job-store/branch_high_priority.py
+++ b/job-board/job-store/branch_high_priority.py
@@ -1,0 +1,277 @@
+"""Bulk-branch high-priority jobs.
+
+For each open job that scores fit > 79 AND live rank > 99, create a branch
+off the latest `origin/main` following the project's branch convention
+(`companyName-jobID-YYYYMMDD`), write `job.txt` with the stored JD, commit,
+and push. The push triggers the existing `process-resume.yaml` workflow.
+
+Usage:
+    .venv/bin/python branch_high_priority.py [--dry-run] [--fit-min N] [--rank-min N]
+    .venv/bin/python branch_high_priority.py --limit 3       # process at most N
+    .venv/bin/python branch_high_priority.py --resume-repo /path/to/repo
+
+Run from the job-store directory (so `db.py` is importable). The resume repo
+defaults to the parent directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+from datetime import datetime, timezone
+from pathlib import Path
+
+import db
+import ranking
+
+
+SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slug(value: str) -> str:
+    """Match the project's existing slug convention (see app.py:_slug)."""
+    return SLUG_RE.sub("", (value or "").lower()) or "unknown"
+
+
+def extract_job_id(url: str, ats_platform: str, row_id: int) -> str:
+    """Best-effort ID to put in the branch name's suffix."""
+    if not url:
+        return str(row_id)
+    try:
+        u = urllib.parse.urlparse(url)
+    except Exception:
+        return str(row_id)
+
+    if ats_platform == "greenhouse":
+        params = urllib.parse.parse_qs(u.query)
+        if "gh_jid" in params:
+            return params["gh_jid"][0]
+        m = re.search(r"/jobs/(\d+)", u.path)
+        if m:
+            return m.group(1)
+
+    if ats_platform == "workday":
+        # Trailing _JR12345, _R12345, or just _12345 segment of the path
+        m = re.search(r"_([A-Z]*\d+)$", u.path)
+        if m:
+            return m.group(1)
+
+    if ats_platform in ("ashby", "lever"):
+        segs = [s for s in u.path.split("/") if s]
+        if segs:
+            # UUID at end — use the first stanza for a shorter branch name.
+            return segs[-1].split("-")[0]
+
+    return str(row_id)
+
+
+def branch_name(company: str, url: str, ats_platform: str, row_id: int,
+                today: str) -> str:
+    return f"{slug(company)}-{extract_job_id(url, ats_platform, row_id)}-{today}"
+
+
+def git(args: list[str], *, cwd: Path, check: bool = True,
+        capture: bool = False) -> subprocess.CompletedProcess:
+    cmd = ["git", *args]
+    return subprocess.run(
+        cmd, cwd=cwd, check=check,
+        capture_output=capture, text=True,
+    )
+
+
+def remote_branch_exists(repo: Path, branch: str) -> bool:
+    """True if `branch` exists on origin. Doesn't fetch — caller refreshes."""
+    result = git(["ls-remote", "--exit-code", "--heads", "origin", branch],
+                 cwd=repo, check=False, capture=True)
+    return result.returncode == 0
+
+
+def local_branch_exists(repo: Path, branch: str) -> bool:
+    result = git(["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+                 cwd=repo, check=False, capture=True)
+    return result.returncode == 0
+
+
+def build_job_txt(row: dict) -> str:
+    header = (
+        f"Title: {row.get('title') or ''}\n"
+        f"Company: {row.get('company') or ''}\n"
+        f"URL: {row.get('url') or ''}\n"
+        f"ATS: {row.get('ats_platform') or 'unknown'}\n"
+        f"Posted: {row.get('posted_at') or ''}\n"
+        f"Discovered: {row.get('discovered_at') or ''}\n"
+        f"\n---\n\n"
+    )
+    return header + (row.get("description") or "").strip() + "\n"
+
+
+def list_candidates(*, fit_min: float, rank_min: float) -> list[tuple[float, dict]]:
+    with db.cursor() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, company, title, fit_score, posted_at, discovered_at,
+                   ats_platform, url, description, branch, status
+            FROM jobs
+            WHERE status IN ('discovered','ranked')
+              AND fit_score IS NOT NULL
+              AND fit_score > ?
+            """,
+            (fit_min,),
+        ).fetchall()
+
+    platform_cache: dict[str | None, tuple] = {}
+    out: list[tuple[float, dict]] = []
+    for r in rows:
+        d = dict(r)
+        ats = d.get("ats_platform")
+        if ats not in platform_cache:
+            platform_cache[ats] = db.get_platform_stats(ats)
+        rank = ranking.compute_rank_score(
+            d.get("fit_score"), d.get("posted_at"), platform_cache[ats],
+            discovered_at=d.get("discovered_at"),
+        )
+        if rank is None or rank <= rank_min:
+            continue
+        out.append((rank, d))
+    out.sort(key=lambda t: -t[0])
+    return out
+
+
+def process_one(row: dict, *, repo: Path, dry_run: bool, today: str) -> dict:
+    name = branch_name(row["company"], row["url"], row.get("ats_platform"),
+                       row["id"], today)
+    summary = {
+        "id": row["id"],
+        "company": row["company"],
+        "title": row["title"],
+        "branch": name,
+        "action": "pending",
+        "detail": "",
+    }
+
+    if not (row.get("description") or "").strip():
+        summary["action"] = "skipped"
+        summary["detail"] = "no description text in DB"
+        return summary
+
+    if local_branch_exists(repo, name) or remote_branch_exists(repo, name):
+        summary["action"] = "skipped"
+        summary["detail"] = "branch already exists"
+        return summary
+
+    if row.get("branch"):
+        summary["action"] = "skipped"
+        summary["detail"] = f"row already tracks branch={row['branch']!r}"
+        return summary
+
+    if dry_run:
+        summary["action"] = "would-create"
+        return summary
+
+    # Create the branch off the freshly-fetched origin/main so this works
+    # even if local main is behind.
+    try:
+        git(["checkout", "-b", name, "origin/main"], cwd=repo, capture=True)
+    except subprocess.CalledProcessError as e:
+        summary["action"] = "error"
+        summary["detail"] = f"checkout failed: {e.stderr or e}"
+        return summary
+
+    try:
+        (repo / "job.txt").write_text(build_job_txt(row), encoding="utf-8")
+        git(["add", "job.txt"], cwd=repo, capture=True)
+        msg = (
+            f"Add {row.get('company','?')} job description ({row.get('title','?')})\n\n"
+            f"Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>\n"
+        )
+        git(["commit", "-m", msg], cwd=repo, capture=True)
+        git(["push", "-u", "origin", name], cwd=repo, capture=True)
+        # Record the branch name back on the row so we don't double-create on
+        # a future run. Keeps status as-is — caller can use the UI's "Mark
+        # applied" button to transition state.
+        db.update_status  # no-op; just a sanity import check
+        with db.cursor() as conn:
+            conn.execute("UPDATE jobs SET branch = ? WHERE id = ?",
+                         (name, row["id"]))
+        summary["action"] = "created"
+    except subprocess.CalledProcessError as e:
+        summary["action"] = "error"
+        summary["detail"] = f"git op failed: {e.stderr or e}"
+    return summary
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="show what would happen; no git ops, no DB writes")
+    parser.add_argument("--fit-min", type=float, default=79.0,
+                        help="minimum fit_score (default: 79)")
+    parser.add_argument("--rank-min", type=float, default=99.0,
+                        help="minimum live rank_score (default: 99)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="process at most N candidates")
+    parser.add_argument("--resume-repo",
+                        default=os.environ.get("RESUME_REPO"),
+                        help="path to the resume repo. Required: pass --resume-repo "
+                             "or set RESUME_REPO env var (e.g. ~/wip/resume).")
+    args = parser.parse_args(argv)
+
+    if not args.resume_repo:
+        print("--resume-repo / RESUME_REPO is required.", file=sys.stderr)
+        return 2
+    repo = Path(args.resume_repo).expanduser().resolve()
+    if not (repo / ".git").exists():
+        print(f"resume repo not found: {repo}", file=sys.stderr)
+        return 2
+
+    # Make sure origin/main is current — branches need to be cut off the
+    # latest commit, not a stale local copy.
+    if not args.dry_run:
+        print(f"Fetching origin/main in {repo} …")
+        git(["fetch", "origin", "main"], cwd=repo, capture=True)
+
+    cands = list_candidates(fit_min=args.fit_min, rank_min=args.rank_min)
+    if args.limit:
+        cands = cands[:args.limit]
+    print(f"{len(cands)} candidates (fit > {args.fit_min}, live rank > {args.rank_min}):")
+    print()
+
+    today = datetime.now(timezone.utc).strftime("%Y%m%d")
+    starting_branch = git(["rev-parse", "--abbrev-ref", "HEAD"],
+                          cwd=repo, capture=True).stdout.strip()
+
+    summaries = []
+    for rank, row in cands:
+        print(f"-- id={row['id']} rank={rank:.1f} fit={row['fit_score']:.0f}"
+              f"  {row['company']}  |  {row['title']}")
+        s = process_one(row, repo=repo, dry_run=args.dry_run, today=today)
+        summaries.append(s)
+        print(f"   → {s['action']}: {s['branch']}{(' — ' + s['detail']) if s['detail'] else ''}")
+
+    if not args.dry_run:
+        # Return to the branch the user started on so we don't leave them on
+        # the last newly-created branch.
+        try:
+            git(["checkout", starting_branch], cwd=repo, capture=True)
+            print(f"\nReturned to {starting_branch}.")
+        except subprocess.CalledProcessError as e:
+            print(f"\nWarning: failed to return to {starting_branch}: {e}",
+                  file=sys.stderr)
+
+    print()
+    print("Summary:")
+    counts: dict[str, int] = {}
+    for s in summaries:
+        counts[s["action"]] = counts.get(s["action"], 0) + 1
+    for action, n in sorted(counts.items()):
+        print(f"  {action}: {n}")
+    errors = [s for s in summaries if s["action"] == "error"]
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/job-board/job-store/csv_import.py
+++ b/job-board/job-store/csv_import.py
@@ -1,0 +1,94 @@
+"""
+One-time import of the existing CSV (`2025 Job Hunt Report - Sheet1.csv`) into
+the jobs/outcomes tables. Brings historical platform success data into the
+ranker so platform_factor starts with real signal instead of zero.
+
+Usage:
+
+    python csv_import.py "../2025 Job Hunt Report - Sheet1.csv"
+
+Imports rows where Applied=TRUE (those are the only ones with outcomes worth
+tracking). Synthesizes a `csv-import://` URL per row since the original
+listing URLs aren't in the CSV.
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import db
+
+
+def _bool(value):
+    return (value or "").strip().upper() == "TRUE"
+
+
+def import_csv(csv_path):
+    inserted = 0
+    skipped = 0
+    duplicates = 0
+
+    with open(csv_path, "r", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if not _bool(row.get("Applied T/F")):
+                skipped += 1
+                continue
+
+            position = (row.get("Position (branch)") or "").strip()
+            company = (row.get("Company") or "").strip()
+            url = f"csv-import://{position}"
+
+            with db.cursor() as conn:
+                exists = conn.execute(
+                    "SELECT id FROM jobs WHERE url = ?", (url,)
+                ).fetchone()
+                if exists:
+                    duplicates += 1
+                    continue
+
+                cur = conn.execute(
+                    """
+                    INSERT INTO jobs (url, company, title, ats_platform, status,
+                                      discovered_by, applied_at)
+                    VALUES (?, ?, ?, ?, 'applied', 'csv-import', CURRENT_TIMESTAMP)
+                    """,
+                    (url, company, position, (row.get("Platform Name") or "").strip()),
+                )
+                job_id = cur.lastrowid
+
+            db.upsert_outcome(
+                job_id,
+                referral=_bool(row.get("Referral")),
+                callback=_bool(row.get("Callback T/F")),
+                ghosted=_bool(row.get("Ghosted")),
+                offer=_bool(row.get("Offer")),
+                notes=(row.get("Notes") or "").strip(),
+            )
+            inserted += 1
+
+    return inserted, skipped, duplicates
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("csv_path", help="Path to the 2025 Job Hunt Report CSV")
+    args = parser.parse_args()
+
+    csv_path = Path(args.csv_path)
+    if not csv_path.exists():
+        print(f"CSV not found: {csv_path}", file=sys.stderr)
+        sys.exit(1)
+
+    db.init_db()
+    inserted, skipped, duplicates = import_csv(csv_path)
+    print(
+        f"Imported {inserted} applied jobs · "
+        f"skipped {skipped} non-applied rows · "
+        f"{duplicates} already in DB"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/job-board/job-store/db.py
+++ b/job-board/job-store/db.py
@@ -1,0 +1,515 @@
+"""SQLite schema and query helpers for the job store."""
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+
+
+DB_PATH = Path(__file__).parent / "jobs.db"
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS jobs (
+    id INTEGER PRIMARY KEY,
+    url TEXT NOT NULL UNIQUE,
+    company TEXT,
+    title TEXT,
+    description TEXT,
+    ats_platform TEXT,
+    posted_at DATE,
+    discovered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    discovered_by TEXT,
+    status TEXT NOT NULL DEFAULT 'discovered',
+    fit_score REAL,
+    analysis_json TEXT,
+    rank_score REAL,
+    applied_at TIMESTAMP,
+    branch TEXT,
+    dedupe_key TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
+CREATE INDEX IF NOT EXISTS idx_jobs_rank ON jobs(rank_score DESC);
+CREATE INDEX IF NOT EXISTS idx_jobs_ats ON jobs(ats_platform);
+-- idx_jobs_dedupe_key is created after the migration step in init_db so it
+-- exists for both fresh DBs (column came in via CREATE TABLE) and migrated
+-- DBs (column added by ALTER TABLE).
+
+CREATE TABLE IF NOT EXISTS outcomes (
+    job_id INTEGER PRIMARY KEY REFERENCES jobs(id) ON DELETE CASCADE,
+    referral INTEGER NOT NULL DEFAULT 0,
+    callback INTEGER NOT NULL DEFAULT 0,
+    callback_at DATE,
+    ghosted INTEGER NOT NULL DEFAULT 0,
+    rejected INTEGER NOT NULL DEFAULT 0,
+    offer INTEGER NOT NULL DEFAULT 0,
+    notes TEXT,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS company_targets (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    careers_url TEXT NOT NULL UNIQUE,
+    ats_platform TEXT,
+    ats_identifier TEXT,
+    deny_list TEXT NOT NULL DEFAULT '[]',
+    last_polled_at TIMESTAMP,
+    last_polled_count INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+"""
+
+
+def get_conn():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db():
+    conn = get_conn()
+    conn.executescript(SCHEMA)
+    # Migration: older DBs were created before `dedupe_key` existed. Add the
+    # column + index if missing, then backfill from existing URLs.
+    existing_cols = {r["name"] for r in conn.execute("PRAGMA table_info(jobs)").fetchall()}
+    if "dedupe_key" not in existing_cols:
+        conn.execute("ALTER TABLE jobs ADD COLUMN dedupe_key TEXT")
+    # Either path (fresh DB or migrated DB) reaches here with the column
+    # in place; create the index unconditionally.
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_jobs_dedupe_key ON jobs(dedupe_key)")
+    # outcomes.rejected was added after the original schema. Older DBs need
+    # the column added explicitly.
+    existing_outcome_cols = {r["name"] for r in conn.execute("PRAGMA table_info(outcomes)").fetchall()}
+    if "rejected" not in existing_outcome_cols:
+        conn.execute("ALTER TABLE outcomes ADD COLUMN rejected INTEGER NOT NULL DEFAULT 0")
+    # Backfill any rows missing a dedupe key. Cheap — runs once per row.
+    from urls import compute_dedupe_key
+    pending = conn.execute("SELECT id, url FROM jobs WHERE dedupe_key IS NULL").fetchall()
+    for r in pending:
+        conn.execute("UPDATE jobs SET dedupe_key = ? WHERE id = ?",
+                     (compute_dedupe_key(r["url"]), r["id"]))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.commit()
+    conn.close()
+
+
+@contextmanager
+def cursor():
+    conn = get_conn()
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Jobs
+# ---------------------------------------------------------------------------
+
+def upsert_job(*, url, company, title, description, ats_platform, posted_at,
+               discovered_by, fit_score, analysis_json):
+    """
+    Insert if the posting (by dedupe_key) is new; otherwise update fit/analysis
+    fields without clobbering applied/branch/status. Returns the row id.
+
+    Lookups go through `dedupe_key` rather than `url` so that two URLs pointing
+    at the same Greenhouse posting (embed wrapper vs. boards-api host) merge
+    into a single row.
+    """
+    from urls import compute_dedupe_key
+    dk = compute_dedupe_key(url)
+    with cursor() as conn:
+        existing = conn.execute(
+            "SELECT id FROM jobs WHERE dedupe_key = ? OR url = ?", (dk, url)
+        ).fetchone()
+        if existing:
+            conn.execute(
+                """
+                UPDATE jobs SET
+                    company = COALESCE(?, company),
+                    title = COALESCE(?, title),
+                    description = COALESCE(?, description),
+                    ats_platform = COALESCE(?, ats_platform),
+                    posted_at = COALESCE(?, posted_at),
+                    discovered_by = COALESCE(?, discovered_by),
+                    fit_score = COALESCE(?, fit_score),
+                    analysis_json = COALESCE(?, analysis_json),
+                    dedupe_key = COALESCE(dedupe_key, ?)
+                WHERE id = ?
+                """,
+                (company, title, description, ats_platform, posted_at,
+                 discovered_by, fit_score, analysis_json, dk, existing["id"]),
+            )
+            return existing["id"]
+        cur = conn.execute(
+            """
+            INSERT INTO jobs (url, company, title, description, ats_platform,
+                              posted_at, discovered_by, fit_score, analysis_json,
+                              status, dedupe_key)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'discovered', ?)
+            """,
+            (url, company, title, description, ats_platform, posted_at,
+             discovered_by, fit_score, analysis_json, dk),
+        )
+        return cur.lastrowid
+
+
+def get_job(job_id):
+    with cursor() as conn:
+        return conn.execute(
+            """
+            SELECT j.*, o.referral, o.callback, o.callback_at, o.ghosted, o.rejected, o.offer, o.notes
+            FROM jobs j
+            LEFT JOIN outcomes o ON o.job_id = j.id
+            WHERE j.id = ?
+            """,
+            (job_id,),
+        ).fetchone()
+
+
+def get_job_by_url(url):
+    """Lookup by dedupe key derived from `url`. Same posting served from
+    different hosts (embed wrapper vs. Greenhouse-direct) lands on the same
+    row. Falls back to URL match for rows that haven't been backfilled yet."""
+    from urls import compute_dedupe_key
+    dk = compute_dedupe_key(url)
+    with cursor() as conn:
+        row = conn.execute(
+            "SELECT * FROM jobs WHERE dedupe_key = ? OR url = ?", (dk, url)
+        ).fetchone()
+        return dict(row) if row else None
+
+
+def list_jobs(*, statuses=None, order="rank_score DESC NULLS LAST"):
+    sql = """
+        SELECT j.*, o.referral, o.callback, o.callback_at, o.ghosted, o.rejected, o.offer, o.notes
+        FROM jobs j
+        LEFT JOIN outcomes o ON o.job_id = j.id
+    """
+    params = []
+    if statuses:
+        placeholders = ",".join(["?"] * len(statuses))
+        sql += f" WHERE j.status IN ({placeholders})"
+        params.extend(statuses)
+    sql += f" ORDER BY {order}"
+    with cursor() as conn:
+        return [dict(r) for r in conn.execute(sql, params).fetchall()]
+
+
+def update_status(job_id, status):
+    with cursor() as conn:
+        conn.execute("UPDATE jobs SET status = ? WHERE id = ?", (status, job_id))
+
+
+def update_rank_score(job_id, rank_score, status=None):
+    with cursor() as conn:
+        if status is not None:
+            conn.execute(
+                "UPDATE jobs SET rank_score = ?, status = ? WHERE id = ?",
+                (rank_score, status, job_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE jobs SET rank_score = ? WHERE id = ?",
+                (rank_score, job_id),
+            )
+
+
+def mark_applied(job_id, branch):
+    with cursor() as conn:
+        conn.execute(
+            """
+            UPDATE jobs SET status = 'applied',
+                            applied_at = CURRENT_TIMESTAMP,
+                            branch = ?
+            WHERE id = ?
+            """,
+            (branch, job_id),
+        )
+
+
+def status_counts():
+    with cursor() as conn:
+        rows = conn.execute(
+            "SELECT status, COUNT(*) AS n FROM jobs GROUP BY status"
+        ).fetchall()
+    counts = {r["status"]: r["n"] for r in rows}
+    counts["open"] = counts.get("discovered", 0) + counts.get("ranked", 0)
+    counts["total"] = sum(r["n"] for r in rows)
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Outcomes
+# ---------------------------------------------------------------------------
+
+def upsert_outcome(job_id, *, referral=False, callback=False, callback_at=None,
+                   ghosted=False, rejected=False, offer=False, notes=""):
+    with cursor() as conn:
+        conn.execute(
+            """
+            INSERT INTO outcomes (job_id, referral, callback, callback_at,
+                                  ghosted, rejected, offer, notes, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(job_id) DO UPDATE SET
+                referral = excluded.referral,
+                callback = excluded.callback,
+                callback_at = excluded.callback_at,
+                ghosted = excluded.ghosted,
+                rejected = excluded.rejected,
+                offer = excluded.offer,
+                notes = excluded.notes,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (job_id, int(referral), int(callback), callback_at,
+             int(ghosted), int(rejected), int(offer), notes),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stats / ranking inputs
+# ---------------------------------------------------------------------------
+
+def get_platform_stats(ats_platform):
+    """
+    Return (platform_callbacks, platform_applied, global_callback_rate).
+    Used by the ranker to compute platform_factor.
+    """
+    with cursor() as conn:
+        global_row = conn.execute(
+            """
+            SELECT
+                SUM(CASE WHEN o.callback = 1 THEN 1 ELSE 0 END) AS cb,
+                COUNT(*) AS applied
+            FROM jobs j JOIN outcomes o ON o.job_id = j.id
+            WHERE j.status = 'applied' OR j.applied_at IS NOT NULL
+            """
+        ).fetchone()
+        plat_row = conn.execute(
+            """
+            SELECT
+                SUM(CASE WHEN o.callback = 1 THEN 1 ELSE 0 END) AS cb,
+                COUNT(*) AS applied
+            FROM jobs j JOIN outcomes o ON o.job_id = j.id
+            WHERE (j.status = 'applied' OR j.applied_at IS NOT NULL)
+              AND j.ats_platform = ?
+            """,
+            (ats_platform,),
+        ).fetchone()
+
+    g_applied = global_row["applied"] or 0
+    g_callbacks = global_row["cb"] or 0
+    p_applied = plat_row["applied"] or 0
+    p_callbacks = plat_row["cb"] or 0
+    global_rate = (g_callbacks / g_applied) if g_applied else 0.0
+    return p_callbacks, p_applied, global_rate
+
+
+def platform_stats_summary():
+    """Counts for the top-of-page banner."""
+    with cursor() as conn:
+        row = conn.execute(
+            """
+            SELECT
+                COUNT(*) AS total_applied,
+                SUM(CASE WHEN o.callback = 1 THEN 1 ELSE 0 END) AS total_callbacks,
+                SUM(CASE WHEN o.offer = 1 THEN 1 ELSE 0 END) AS total_offers
+            FROM jobs j JOIN outcomes o ON o.job_id = j.id
+            WHERE j.status = 'applied' OR j.applied_at IS NOT NULL
+            """
+        ).fetchone()
+
+    total_applied = row["total_applied"] or 0
+    total_callbacks = row["total_callbacks"] or 0
+    total_offers = row["total_offers"] or 0
+    rate_pct = round(100 * total_callbacks / total_applied, 1) if total_applied else 0.0
+    return {
+        "total_applied": total_applied,
+        "total_callbacks": total_callbacks,
+        "total_offers": total_offers,
+        "callback_rate_pct": rate_pct,
+    }
+
+
+def all_jobs_for_rerank():
+    with cursor() as conn:
+        return [dict(r) for r in conn.execute(
+            "SELECT id, fit_score, posted_at, discovered_at, ats_platform "
+            "FROM jobs WHERE fit_score IS NOT NULL"
+        ).fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# Company targets (per-company polling config for the discovery bot)
+# ---------------------------------------------------------------------------
+
+def list_company_targets():
+    with cursor() as conn:
+        return [dict(r) for r in conn.execute(
+            "SELECT * FROM company_targets ORDER BY name COLLATE NOCASE ASC"
+        ).fetchall()]
+
+
+def get_company_target(target_id):
+    with cursor() as conn:
+        row = conn.execute(
+            "SELECT * FROM company_targets WHERE id = ?", (target_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+
+def create_company_target(*, name, careers_url, ats_platform, ats_identifier,
+                          deny_list=None):
+    with cursor() as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO company_targets
+                (name, careers_url, ats_platform, ats_identifier, deny_list)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                name,
+                careers_url,
+                ats_platform,
+                json.dumps(ats_identifier) if ats_identifier else None,
+                json.dumps(deny_list or []),
+            ),
+        )
+        return cur.lastrowid
+
+
+def update_company_target(target_id, *, name=None, deny_list=None,
+                          ats_platform=None, ats_identifier=None,
+                          last_polled_at=None, last_polled_count=None):
+    fields = []
+    values = []
+    if name is not None:
+        fields.append("name = ?")
+        values.append(name)
+    if deny_list is not None:
+        fields.append("deny_list = ?")
+        values.append(json.dumps(deny_list))
+    if ats_platform is not None:
+        fields.append("ats_platform = ?")
+        values.append(ats_platform)
+    if ats_identifier is not None:
+        fields.append("ats_identifier = ?")
+        values.append(json.dumps(ats_identifier))
+    if last_polled_at is not None:
+        fields.append("last_polled_at = ?")
+        values.append(last_polled_at)
+    if last_polled_count is not None:
+        fields.append("last_polled_count = ?")
+        values.append(last_polled_count)
+    if not fields:
+        return
+    fields.append("updated_at = CURRENT_TIMESTAMP")
+    values.append(target_id)
+    with cursor() as conn:
+        conn.execute(
+            f"UPDATE company_targets SET {', '.join(fields)} WHERE id = ?",
+            values,
+        )
+
+
+def delete_company_target(target_id):
+    with cursor() as conn:
+        conn.execute("DELETE FROM company_targets WHERE id = ?", (target_id,))
+
+
+def parse_company_target(row):
+    """Decode the JSON columns into Python values for templates / API responses."""
+    row = dict(row)
+    try:
+        row["deny_list"] = json.loads(row.get("deny_list") or "[]")
+    except (TypeError, ValueError):
+        row["deny_list"] = []
+    if row.get("ats_identifier"):
+        try:
+            row["ats_identifier_parsed"] = json.loads(row["ats_identifier"])
+        except (TypeError, ValueError):
+            row["ats_identifier_parsed"] = None
+    else:
+        row["ats_identifier_parsed"] = None
+    return row
+
+
+# ---------------------------------------------------------------------------
+# JSON helpers
+# ---------------------------------------------------------------------------
+
+def parse_analysis(analysis_json):
+    if not analysis_json:
+        return {}
+    try:
+        return json.loads(analysis_json)
+    except (TypeError, ValueError):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Settings — key/value store for things like the stale-cleanup threshold.
+# ---------------------------------------------------------------------------
+
+def get_setting(key, default=None):
+    with cursor() as conn:
+        row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+    return row["value"] if row else default
+
+
+def set_setting(key, value):
+    with cursor() as conn:
+        conn.execute(
+            """
+            INSERT INTO settings (key, value, updated_at)
+            VALUES (?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (key, str(value)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cleanup helpers
+# ---------------------------------------------------------------------------
+
+def list_cleanup_candidates():
+    """Rows eligible for stale-cleanup: not applied, not closed, no recorded
+    outcome data. Returns id, url, discovered_at."""
+    with cursor() as conn:
+        return [dict(r) for r in conn.execute(
+            """
+            SELECT j.id, j.url, j.discovered_at
+            FROM jobs j
+            LEFT JOIN outcomes o ON o.job_id = j.id
+            WHERE j.status IN ('discovered', 'ranked')
+              AND (o.job_id IS NULL OR
+                   (o.callback = 0 AND o.offer = 0 AND o.referral = 0
+                    AND o.rejected = 0 AND o.ghosted = 0
+                    AND COALESCE(o.notes, '') = ''))
+            """
+        ).fetchall()]
+
+
+def delete_jobs(job_ids):
+    """Bulk delete by id. Outcomes rows cascade via ON DELETE CASCADE."""
+    if not job_ids:
+        return 0
+    placeholders = ",".join(["?"] * len(job_ids))
+    with cursor() as conn:
+        cur = conn.execute(f"DELETE FROM jobs WHERE id IN ({placeholders})", list(job_ids))
+        return cur.rowcount

--- a/job-board/job-store/poller.py
+++ b/job-board/job-store/poller.py
@@ -1,0 +1,375 @@
+"""Targeted-company poller.
+
+For each `company_targets` row whose `ats_platform` has an adapter, fetch the
+current list of openings, dedupe against existing `jobs.url`, filter titles
+against the target's `deny_list`, and POST the survivors to `/jobs/score`
+(without `fit_score`, so the backend's server-side Claude scorer runs).
+
+CLI:
+
+    .venv/bin/python poller.py                # poll all greenhouse targets
+    .venv/bin/python poller.py --dry-run      # print actions, no POSTs, no DB writes
+    .venv/bin/python poller.py --target 5     # poll only target id=5
+    .venv/bin/python poller.py --backend http://127.0.0.1:5000
+
+Requires the Flask backend to be reachable (POST /jobs/score). The poller
+reads `company_targets` and existing job URLs directly from `jobs.db` to keep
+the dedupe + filter work local; only the scoring round-trip goes over HTTP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+import db
+from adapters import ADAPTERS
+
+
+DEFAULT_BACKEND = "http://127.0.0.1:5000"
+
+# Persisted in the `settings` table; user overrides via --set-locations and
+# --set-deny-locations. The denylist wins ties so that postings like
+# "Sweden | Remote" or "Toronto, Canada" are rejected even though "Remote"
+# is in the allowlist (a Grafana-style cross-region listing should only
+# survive for the US variant).
+LOCATION_ALLOWLIST_KEY = "location_allowlist"
+LOCATION_DENYLIST_KEY = "location_denylist"
+DEFAULT_LOCATION_ALLOWLIST = [
+    "United States", "USA", "U.S.",
+    "US-",   # Workday URL-path format: US-CA-Santa-Clara
+    "US,",   # Workday CXS list format: "US, CA, Santa Clara"
+    "US |",  # Greenhouse pipe-delimited: "Title | US | Remote"
+    "Americas", "North America",
+    # Workday's CXS list endpoint collapses multi-region postings to strings
+    # like "13 Locations" — we can't tell which of those are US without
+    # fetching the detail page, so accept and let scoring sort it out.
+    "Locations",
+    # Note: "Remote" is intentionally NOT here. A posting like
+    # "Sweden | Remote" should reject on Sweden via denylist, and a posting
+    # like plain "Remote" falls through to allow via the no-match default.
+]
+DEFAULT_LOCATION_DENYLIST = [
+    # Countries / regions seen in recent polls. Add new ones as they surface.
+    "Canada", "Toronto", "Montreal", "Vancouver",
+    "United Kingdom", " UK ", "| UK", "UK |", "London",
+    "Ireland", "Dublin",
+    "Germany", "Berlin", "Munich",
+    "Spain", "Barcelona", "Madrid",
+    "Sweden", "Stockholm",
+    "Netherlands", "Amsterdam",
+    "France", "Paris",
+    "Israel", "Tel Aviv", "Yokneam",
+    "India", "Bengaluru", "Pune", "Hyderabad", "Mumbai",
+    "Taiwan", "Taipei", "China", "Japan", "Tokyo",
+    "Australia", "Sydney",
+    "LATAM", "EMEA", "APAC", "ASEAN", "DACH", "ANZ",
+]
+
+
+def _existing_urls() -> set[str]:
+    with db.cursor() as conn:
+        rows = conn.execute("SELECT url FROM jobs").fetchall()
+    return {r["url"] for r in rows}
+
+
+def _is_denied(title: str, deny_list: list[str]) -> str | None:
+    """Return the matching deny phrase, or None if the title passes."""
+    t = (title or "").lower()
+    for phrase in deny_list or []:
+        if not phrase:
+            continue
+        if phrase.lower() in t:
+            return phrase
+    return None
+
+
+def _load_list_setting(key: str, default: list[str]) -> list[str]:
+    raw = db.get_setting(key)
+    if raw is None:
+        return list(default)
+    parts = [p.strip() for p in raw.split(",")]
+    return [p for p in parts if p]
+
+
+def _load_location_allowlist() -> list[str]:
+    return _load_list_setting(LOCATION_ALLOWLIST_KEY, DEFAULT_LOCATION_ALLOWLIST)
+
+
+def _load_location_denylist() -> list[str]:
+    return _load_list_setting(LOCATION_DENYLIST_KEY, DEFAULT_LOCATION_DENYLIST)
+
+
+def _location_allowed(loc: str, allowlist: list[str], denylist: list[str]) -> str | None:
+    """Return None if allowed; otherwise return a human-readable reason.
+
+    Semantics:
+    - Empty location → allowed (don't reject on missing data).
+    - Allowlist match → allowed (positive override beats denylist; lets a
+      multi-region posting like "United States, Canada" survive even though
+      "Canada" is in the denylist).
+    - Otherwise denylist match → rejected.
+    - Otherwise → allowed (permissive default: an unknown country slips
+      through, which the user can patch via --set-deny-locations).
+    """
+    if not loc:
+        return None
+    low = loc.lower()
+    for p in allowlist or []:
+        if p and p.lower() in low:
+            return None
+    for p in denylist or []:
+        if p and p.lower() in low:
+            return f"deny:{p!r}"
+    return None
+
+
+def _post_score(backend: str, job: dict, target_name: str) -> tuple[bool, dict | str]:
+    payload = {
+        "url": job["url"],
+        "title": job.get("title"),
+        "description": job.get("description"),
+        "posted_at": job.get("posted_at"),
+        "ats_platform": job.get("ats_platform"),
+        "discovered_by": f"poller:{target_name}",
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{backend.rstrip('/')}/jobs/score",
+        data=body,
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    try:
+        # Server-side scoring takes ~5-10s per JD on cache hits — generous timeout.
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return True, json.load(resp)
+    except urllib.error.HTTPError as e:
+        return False, f"HTTP {e.code}: {e.read().decode('utf-8', errors='replace')[:200]}"
+    except urllib.error.URLError as e:
+        return False, f"URL error: {e.reason}"
+
+
+def poll_target(target: dict, *, backend: str, existing_urls: set[str],
+                dry_run: bool, max_new: int | None,
+                location_allowlist: list[str],
+                location_denylist: list[str]) -> dict:
+    name = target.get("name") or "unnamed"
+    platform = target.get("ats_platform")
+    adapter = ADAPTERS.get(platform)
+
+    summary = {
+        "id": target["id"],
+        "name": name,
+        "platform": platform,
+        "found": 0,
+        "new": 0,
+        "denied": 0,
+        "out_of_region": 0,
+        "scored": 0,
+        "errors": 0,
+        "skipped": 0,
+        "stopped_at_seen": False,
+        "max_new_reached": False,
+        "error_detail": [],
+    }
+
+    if not adapter:
+        # Not a transient error — the target was registered with an ATS the
+        # poller doesn't know how to talk to. Surface it visibly but don't
+        # treat it as a failure for exit-code purposes.
+        print(f"  {name} ({platform}): no adapter for this ATS — skipping")
+        summary["skipped"] = 1
+        return summary
+
+    identifier = target.get("ats_identifier_parsed") or {}
+    deny_list = target.get("deny_list") or []
+
+    try:
+        jobs = adapter.list_jobs(identifier)
+    except Exception as e:
+        summary["errors"] = 1
+        summary["error_detail"].append(f"adapter error: {e}")
+        return summary
+
+    summary["found"] = len(jobs)
+    print(f"  {name} ({platform}): found {len(jobs)} openings (newest-first)")
+
+    for job in jobs:
+        if not job.get("url") or not job.get("title"):
+            continue
+        # Stop-when-seen: adapters return newest-first, so the first time we
+        # hit a URL we already have, every job below it is older and either
+        # known or deny-listed — no point continuing.
+        if job["url"] in existing_urls:
+            summary["stopped_at_seen"] = True
+            print(f"    stop [already seen] {job['title']}")
+            break
+
+        denied = _is_denied(job["title"], deny_list)
+        if denied:
+            summary["denied"] += 1
+            print(f"    skip [deny: {denied!r}] {job['title']}")
+            continue
+
+        # Location check before the description fetch — skip cheaply on
+        # geography before we spend any HTTP / Anthropic budget on a role
+        # the user wouldn't take.
+        loc = job.get("location") or ""
+        reason = _location_allowed(loc, location_allowlist, location_denylist)
+        if reason is not None:
+            summary["out_of_region"] += 1
+            print(f"    skip [location {reason} for {loc!r}] {job['title']}")
+            continue
+
+        if max_new is not None and summary["new"] >= max_new:
+            summary["max_new_reached"] = True
+            print(f"    stop [--max-new {max_new} reached] (more openings unreviewed)")
+            break
+
+        # Lazy description fetch — only for jobs that survived dedupe+deny.
+        # For Greenhouse/Ashby/Lever this is a no-op (descriptions are inline);
+        # for Workday it issues the per-posting detail HTTP call.
+        if not job.get("description"):
+            try:
+                job["description"] = adapter.fetch_description(job)
+            except Exception as e:
+                summary["errors"] += 1
+                summary["error_detail"].append(f"detail fetch failed for {job['title']}: {e}")
+                print(f"    ERROR fetching detail for {job['title']}: {e}")
+                continue
+        if not job.get("description") or len(job["description"]) < 100:
+            summary["errors"] += 1
+            summary["error_detail"].append(f"{job['title']}: description too short to score")
+            print(f"    skip [no description]   {job['title']}")
+            continue
+
+        summary["new"] += 1
+        job["ats_platform"] = platform
+        if dry_run:
+            print(f"    dry-run [would POST]    {job['title']}  ({len(job['description'])}c)")
+            continue
+        ok, result = _post_score(backend, job, name)
+        if ok:
+            summary["scored"] += 1
+            existing_urls.add(job["url"])
+            fs = result.get("fit_score")
+            print(f"    scored fit={fs}  {job['title']}")
+        else:
+            summary["errors"] += 1
+            summary["error_detail"].append(f"{job['title']}: {result}")
+            print(f"    ERROR  {job['title']}: {result}")
+
+    if not dry_run:
+        db.update_company_target(
+            target["id"],
+            last_polled_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            last_polled_count=summary["found"],
+        )
+
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Poll company_targets for new openings.")
+    parser.add_argument("--backend", default=DEFAULT_BACKEND,
+                        help=f"job-store base URL (default: {DEFAULT_BACKEND})")
+    parser.add_argument("--target", type=int, default=None,
+                        help="poll only this target id")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print actions, no POSTs, no DB writes")
+    parser.add_argument("--max-new", type=int, default=None,
+                        help="cap the number of new jobs scored per target this run "
+                             "(useful for first-poll budget on big Workday tenants)")
+    parser.add_argument("--locations", default=None,
+                        help="comma-separated location allowlist override for this "
+                             "run only (e.g. 'United States,Remote,US-')")
+    parser.add_argument("--set-locations", default=None,
+                        help="persist the comma-separated allowlist to settings and exit")
+    parser.add_argument("--deny-locations", default=None,
+                        help="comma-separated location denylist override for this run only")
+    parser.add_argument("--set-deny-locations", default=None,
+                        help="persist the comma-separated denylist to settings and exit")
+    parser.add_argument("--show-locations", action="store_true",
+                        help="print the currently-configured allow- and deny-lists and exit")
+    args = parser.parse_args(argv)
+
+    # One-shot settings management — never polls.
+    if args.set_locations is not None:
+        db.set_setting(LOCATION_ALLOWLIST_KEY, args.set_locations)
+        print(f"location_allowlist set to: {args.set_locations!r}")
+        return 0
+    if args.set_deny_locations is not None:
+        db.set_setting(LOCATION_DENYLIST_KEY, args.set_deny_locations)
+        print(f"location_denylist set to: {args.set_deny_locations!r}")
+        return 0
+    if args.show_locations:
+        print(f"allowlist: {', '.join(_load_location_allowlist())}")
+        print(f"denylist:  {', '.join(_load_location_denylist())}")
+        return 0
+
+    targets = [db.parse_company_target(t) for t in db.list_company_targets()]
+    if args.target is not None:
+        targets = [t for t in targets if t["id"] == args.target]
+        if not targets:
+            print(f"no target with id={args.target}", file=sys.stderr)
+            return 2
+
+    if not targets:
+        print("no company_targets configured.", file=sys.stderr)
+        return 1
+
+    existing = _existing_urls()
+    location_allowlist = (
+        [p.strip() for p in args.locations.split(",") if p.strip()]
+        if args.locations else _load_location_allowlist()
+    )
+    location_denylist = (
+        [p.strip() for p in args.deny_locations.split(",") if p.strip()]
+        if args.deny_locations else _load_location_denylist()
+    )
+    print(f"Polling {len(targets)} target(s)  (dry-run={args.dry_run}, backend={args.backend})")
+    print(f"Existing jobs in DB: {len(existing)}")
+    if location_allowlist:
+        print(f"Location allowlist: {', '.join(location_allowlist)}")
+    if location_denylist:
+        print(f"Location denylist:  {', '.join(location_denylist)}")
+
+    started = time.time()
+    summaries = []
+    for t in targets:
+        summaries.append(poll_target(t, backend=args.backend,
+                                     existing_urls=existing,
+                                     dry_run=args.dry_run,
+                                     max_new=args.max_new,
+                                     location_allowlist=location_allowlist,
+                                     location_denylist=location_denylist))
+
+    elapsed = time.time() - started
+    total_found = sum(s["found"] for s in summaries)
+    total_new = sum(s["new"] for s in summaries)
+    total_scored = sum(s["scored"] for s in summaries)
+    total_denied = sum(s["denied"] for s in summaries)
+    total_errors = sum(s["errors"] for s in summaries)
+    total_skipped = sum(s["skipped"] for s in summaries)
+    total_out_of_region = sum(s["out_of_region"] for s in summaries)
+
+    print()
+    print(f"Done in {elapsed:.1f}s.  found={total_found}  new={total_new}  "
+          f"denied={total_denied}  out_of_region={total_out_of_region}  "
+          f"scored={total_scored}  skipped={total_skipped}  errors={total_errors}")
+    if total_errors:
+        print("\nErrors:")
+        for s in summaries:
+            for msg in s["error_detail"]:
+                print(f"  [{s['name']}] {msg}")
+    return 0 if total_errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/job-board/job-store/ranking.py
+++ b/job-board/job-store/ranking.py
@@ -1,0 +1,74 @@
+"""
+Ranking math. See AUTOMATION_PLAN.md §Ranking for the source formula and the
+rationale behind each constant.
+
+  rank_score = fit_score * age_decay(posted_at) * platform_factor(...)
+"""
+
+from datetime import date
+
+
+# Tunable constants. See AUTOMATION_PLAN.md for rationale; expect to revisit
+# once ≥30 outcomes exist in the system.
+AGE_DECAY_DAYS = 45
+AGE_DECAY_FLOOR = 0.3
+UNKNOWN_AGE_FACTOR = 0.7
+
+PLATFORM_FACTOR_MIN = 0.5
+PLATFORM_FACTOR_MAX = 1.5
+
+# Bayesian smoothing prior — pretends every platform starts with 2 callbacks
+# out of 10 applications, dragging low-n platforms toward the global rate.
+SMOOTHING_PRIOR_CALLBACKS = 2
+SMOOTHING_PRIOR_APPLICATIONS = 10
+
+# Used when there is no historical data at all (empty store).
+DEFAULT_GLOBAL_CALLBACK_RATE = 0.10
+
+
+def _parse_date(d):
+    if not d:
+        return None
+    if isinstance(d, date):
+        return d
+    try:
+        return date.fromisoformat(str(d)[:10])
+    except ValueError:
+        return None
+
+
+def age_decay(posted_at):
+    parsed = _parse_date(posted_at)
+    if parsed is None:
+        return UNKNOWN_AGE_FACTOR
+    days = (date.today() - parsed).days
+    if days < 0:
+        return 1.0
+    return max(AGE_DECAY_FLOOR, min(1.0, 1.0 - days / AGE_DECAY_DAYS))
+
+
+def platform_factor(platform_callbacks, platform_applied, global_callback_rate):
+    if global_callback_rate <= 0:
+        global_callback_rate = DEFAULT_GLOBAL_CALLBACK_RATE
+    smoothed = (platform_callbacks + SMOOTHING_PRIOR_CALLBACKS) / (
+        platform_applied + SMOOTHING_PRIOR_APPLICATIONS
+    )
+    raw = 0.5 + (smoothed / global_callback_rate) * 0.5
+    return max(PLATFORM_FACTOR_MIN, min(PLATFORM_FACTOR_MAX, raw))
+
+
+def compute_rank_score(fit_score, posted_at, platform_stats, discovered_at=None):
+    """
+    platform_stats = (platform_callbacks, platform_applied, global_callback_rate)
+
+    Falls back to `discovered_at` when `posted_at` is missing — most plugin
+    POSTs and some Workday postings don't carry an explicit publish date, and
+    without a fallback those rows freeze at `UNKNOWN_AGE_FACTOR` forever
+    instead of aging out alongside everything else.
+    """
+    if fit_score is None:
+        return None
+    p_cb, p_app, g_rate = platform_stats
+    decay = age_decay(posted_at) if posted_at else age_decay(discovered_at)
+    factor = platform_factor(p_cb, p_app, g_rate)
+    return round(fit_score * decay * factor, 2)

--- a/job-board/job-store/requirements.txt
+++ b/job-board/job-store/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0
+anthropic>=0.40

--- a/job-board/job-store/static/style.css
+++ b/job-board/job-store/static/style.css
@@ -1,0 +1,251 @@
+* { box-sizing: border-box; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
+  color: #1a1a1a;
+  background: #f5f5f7;
+  margin: 0;
+}
+
+header {
+  background: #fff;
+  border-bottom: 1px solid #e5e5e5;
+  padding: 16px 24px;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+header h1 {
+  font-size: 18px;
+  margin: 0 0 8px;
+}
+
+nav {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+nav a {
+  padding: 4px 10px;
+  border-radius: 4px;
+  text-decoration: none;
+  color: #555;
+  font-size: 13px;
+}
+nav a:hover { background: #f0f0f0; }
+nav a.active { background: #1a1a1a; color: #fff; }
+
+.stats {
+  display: flex;
+  gap: 18px;
+  font-size: 12px;
+  color: #666;
+  align-items: center;
+}
+.stats .inline { margin-left: auto; }
+.stats button.link {
+  background: none;
+  border: none;
+  color: #1a4f8b;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+  text-decoration: underline;
+}
+.cleanup-form {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.cleanup-label {
+  color: #666;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.cleanup-days {
+  width: 3.5em;
+  padding: 1px 4px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  font-size: 12px;
+}
+.cleanup-summary {
+  background: #d1ecf1;
+  color: #0c5460;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  margin-top: 6px;
+}
+
+main {
+  max-width: 1100px;
+  margin: 24px auto;
+  padding: 0 24px;
+}
+
+.empty {
+  text-align: center;
+  color: #888;
+  padding: 40px 0;
+}
+
+article.job {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 6px;
+  padding: 14px 18px;
+  margin-bottom: 10px;
+  display: grid;
+  grid-template-columns: 70px 1fr 200px;
+  gap: 18px;
+  align-items: start;
+}
+
+.rank-col {
+  text-align: center;
+}
+.rank-col .rank {
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1;
+}
+.rank-col .fit {
+  font-size: 11px;
+  color: #888;
+  margin-top: 4px;
+}
+
+.rank-col .poller-badge {
+  font-size: 16px;
+  margin-top: 4px;
+  line-height: 1;
+  cursor: help;
+}
+
+article.rec-strong_match .rank-col .rank { color: #155724; }
+article.rec-consider     .rank-col .rank { color: #0c5460; }
+article.rec-weak_match   .rank-col .rank { color: #856404; }
+article.rec-skip         .rank-col .rank { color: #721c24; }
+
+.info .title {
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none;
+  color: #1a1a1a;
+}
+.info .title:hover { text-decoration: underline; }
+.info .dim { color: #aaa; font-weight: normal; }
+
+.meta {
+  display: flex;
+  gap: 10px;
+  font-size: 11px;
+  color: #888;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+.meta .ats { text-transform: uppercase; letter-spacing: 0.5px; }
+
+.status {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: #eee;
+  color: #555;
+}
+.status-applied { background: #d4edda; color: #155724; }
+.status-closed  { background: #f8d7da; color: #721c24; }
+.status-ranked  { background: #d1ecf1; color: #0c5460; }
+
+.rec-pill {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.rec-pill.rec-strong_match { background: #d4edda; color: #155724; }
+.rec-pill.rec-consider     { background: #d1ecf1; color: #0c5460; }
+.rec-pill.rec-weak_match   { background: #fff3cd; color: #856404; }
+.rec-pill.rec-skip         { background: #f8d7da; color: #721c24; }
+
+.summary {
+  background: #f7f7f7;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-style: italic;
+  margin: 8px 0 4px;
+  color: #444;
+}
+
+details.analysis, details.outcome-form {
+  margin-top: 6px;
+  font-size: 13px;
+}
+details.analysis summary, details.outcome-form summary {
+  cursor: pointer;
+  color: #1a4f8b;
+  font-weight: 600;
+}
+details.analysis h4 { margin: 8px 0 2px; font-size: 12px; text-transform: uppercase; color: #666; letter-spacing: 0.5px; }
+details.analysis ul { margin: 0 0 6px; padding-left: 20px; }
+details.analysis li { margin-bottom: 2px; }
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: stretch;
+}
+.actions form { margin: 0; }
+.actions button {
+  width: 100%;
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  background: #fafafa;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.actions button.primary {
+  background: #1a1a1a;
+  color: #fff;
+  border-color: #1a1a1a;
+}
+.actions button:hover { opacity: 0.85; }
+
+.branch {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: #888;
+  text-align: center;
+  margin-bottom: 4px;
+  word-break: break-all;
+}
+
+.outcome-form form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 6px;
+}
+.outcome-form label {
+  font-size: 12px;
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+.outcome-form textarea {
+  font-family: inherit;
+  font-size: 12px;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  resize: vertical;
+}

--- a/job-board/job-store/templates/companies.html
+++ b/job-board/job-store/templates/companies.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Targeted Companies — Job Inbox</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  <style>
+    /* Page-specific styles. Keep main style.css untouched. */
+    .top-nav { display: flex; gap: 1rem; margin-bottom: 0.5rem; }
+    .top-nav a { font-weight: 600; }
+    .top-nav a.active { text-decoration: underline; }
+
+    .add-company {
+      background: #f6f6f8;
+      padding: 1rem;
+      border-radius: 6px;
+      margin-bottom: 1.5rem;
+    }
+    .add-company form {
+      display: grid;
+      grid-template-columns: 1fr 1fr auto;
+      gap: 0.75rem;
+      align-items: end;
+    }
+    .add-company label { display: flex; flex-direction: column; font-size: 0.9rem; }
+    .add-company input[type="url"],
+    .add-company input[type="text"] {
+      padding: 0.4rem 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.95rem;
+    }
+    .hint { font-size: 0.85rem; color: #666; margin: 0.5rem 0 0; }
+    .add-error {
+      background: #fdecea;
+      border: 1px solid #f3b6b3;
+      color: #722;
+      padding: 0.6rem 0.8rem;
+      border-radius: 4px;
+      margin: 0 0 0.75rem;
+      font-size: 0.92rem;
+    }
+    .ats.ats-other { background: #fff3cd; color: #856404; }
+    .unpollable {
+      background: #fff3cd;
+      color: #856404;
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .company-target {
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      margin-bottom: 0.75rem;
+    }
+    .company-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .company-header h3 { margin: 0; }
+    .company-header .meta {
+      display: flex;
+      gap: 0.75rem;
+      font-size: 0.85rem;
+      color: #555;
+    }
+    .meta .ats {
+      background: #eef;
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      font-family: monospace;
+    }
+    .meta .dim { color: #999; }
+
+    .edit-target { margin-top: 0.5rem; }
+    .edit-target summary {
+      cursor: pointer;
+      color: #555;
+      font-size: 0.9rem;
+    }
+    .edit-target form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+      margin-top: 0.6rem;
+    }
+    .edit-target label {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      font-size: 0.9rem;
+    }
+    .edit-target textarea {
+      font-family: monospace;
+      font-size: 0.9rem;
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      resize: vertical;
+    }
+    .form-actions { display: flex; gap: 0.5rem; }
+    .delete-form { margin-top: 0.5rem; }
+    button.danger {
+      background: #fff;
+      color: #b00;
+      border: 1px solid #b00;
+      padding: 0.3rem 0.7rem;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+    button.danger:hover { background: #fee; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Targeted Companies</h1>
+    <div class="top-nav">
+      <a href="/">Inbox</a>
+      <a href="/companies" class="active">Companies ({{ targets|length }})</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="add-company">
+      <h2>Add company</h2>
+      {% if add_error %}
+        <div class="add-error">{{ add_error }}</div>
+      {% endif %}
+      <form method="post" action="/companies">
+        <label>
+          Careers URL
+          <input type="url" name="careers_url" required
+                 value="{{ add_url or '' }}"
+                 placeholder="https://job-boards.greenhouse.io/chainguard">
+        </label>
+        <label>
+          Name (optional)
+          <input type="text" name="name" value="{{ add_name or '' }}"
+                 placeholder="auto-detected if blank">
+        </label>
+        <button type="submit" class="primary">Add</button>
+      </form>
+      <p class="hint">
+        Supported ATSes: Greenhouse, Ashby, Lever, Workday. If you paste a wrapper
+        page (e.g., <code>company.com/careers/</code>), we'll fetch it and try to
+        resolve the underlying board automatically.
+      </p>
+    </section>
+
+    {% if not targets %}
+      <p class="empty">No companies targeted yet. Paste a careers URL above to add one.</p>
+    {% endif %}
+
+    {% for t in targets %}
+      <article class="company-target">
+        <div class="company-header">
+          <h3>{{ t.name }}</h3>
+          <div class="meta">
+            <span class="ats ats-{{ t.ats_platform or 'other' }}">{{ t.ats_platform or 'other' }}</span>
+            {% if t.ats_platform == 'other' %}
+              <span class="unpollable" title="No adapter — poller skips this target">⚠ unpollable</span>
+            {% endif %}
+            {% if t.last_polled_at %}
+              <span class="age">{{ t.last_polled_label }} · {{ t.last_polled_count }} jobs</span>
+            {% else %}
+              <span class="age dim">never polled</span>
+            {% endif %}
+            <a href="{{ t.careers_url }}" target="_blank" rel="noopener">careers&nbsp;↗</a>
+          </div>
+        </div>
+
+        <details class="edit-target">
+          <summary>Edit ({{ t.deny_list|length }} deny terms)</summary>
+          <form method="post" action="/companies/{{ t.id }}">
+            <label>
+              Name
+              <input type="text" name="name" value="{{ t.name }}">
+            </label>
+            <label>
+              Deny list — one term per line. Case-insensitive substring match against role titles.
+              <textarea name="deny_list" rows="8"
+                placeholder="Sales&#10;Marketing&#10;Customer Success&#10;Intern">{{ t.deny_list|join('\n') }}</textarea>
+            </label>
+            <div class="form-actions">
+              <button type="submit" class="primary">Save</button>
+            </div>
+          </form>
+          <form method="post" action="/companies/{{ t.id }}/delete" class="delete-form"
+                onsubmit="return confirm('Remove {{ t.name }} from targets? Jobs already scored from this company are not affected.');">
+            <button type="submit" class="danger">Delete this company</button>
+          </form>
+        </details>
+      </article>
+    {% endfor %}
+  </main>
+</body>
+</html>

--- a/job-board/job-store/templates/index.html
+++ b/job-board/job-store/templates/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Job Inbox</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <header>
+    <h1>Job Inbox</h1>
+    <div style="display: flex; gap: 1rem; margin-bottom: 0.5rem; font-weight: 600;">
+      <a href="/" style="text-decoration: underline;">Inbox</a>
+      <a href="/companies">Companies</a>
+    </div>
+    <nav>
+      <a href="?status=open" class="{{ 'active' if filter_status == 'open' else '' }}">Open ({{ counts.open or 0 }})</a>
+      <a href="?status=applied" class="{{ 'active' if filter_status == 'applied' else '' }}">Applied ({{ counts.applied or 0 }})</a>
+      <a href="?status=closed" class="{{ 'active' if filter_status == 'closed' else '' }}">Closed ({{ counts.closed or 0 }})</a>
+      <a href="?status=all" class="{{ 'active' if filter_status == 'all' else '' }}">All ({{ counts.total or 0 }})</a>
+    </nav>
+    <div class="stats">
+      <span><strong>{{ stats.total_applied }}</strong> applied</span>
+      <span><strong>{{ stats.total_callbacks }}</strong> callbacks ({{ stats.callback_rate_pct }}%)</span>
+      <span><strong>{{ stats.total_offers }}</strong> offers</span>
+      <form method="post" action="/admin/rerank" class="inline">
+        <button type="submit" class="link">re-rank all</button>
+      </form>
+      <form method="post" action="/admin/cleanup" class="inline cleanup-form"
+            onsubmit="return confirm('Delete unscored / non-applied jobs older than ' + this.days.value + ' days or whose URLs no longer resolve? Applied jobs are kept.');">
+        <input type="hidden" name="status" value="{{ filter_status }}">
+        <label class="cleanup-label">cleanup
+          <input type="number" name="days" value="{{ cleanup_days }}" min="1" max="365" class="cleanup-days">
+          d
+        </label>
+        <button type="submit" class="link">clean up stale</button>
+      </form>
+    </div>
+    {% if cleanup_summary %}
+      <div class="cleanup-summary">
+        Cleanup done: {{ cleanup_summary.total }} removed
+        ({{ cleanup_summary.age }} aged out, {{ cleanup_summary.dead }} dead links).
+      </div>
+    {% endif %}
+  </header>
+
+  <main>
+    {% if not jobs %}
+      <p class="empty">No jobs in this view yet.</p>
+    {% endif %}
+
+    {% for job in jobs %}
+      <article class="job rec-{{ job.recommendation or 'unknown' }}">
+        <div class="rank-col">
+          <div class="rank">{{ "%.0f"|format(job.rank_score) if job.rank_score is not none else '—' }}</div>
+          <div class="fit">fit {{ job.fit_score|int if job.fit_score is not none else '—' }}</div>
+          {% if job.discovered_by and job.discovered_by.startswith('poller:') %}
+            <div class="poller-badge" title="Auto-discovered by {{ job.discovered_by[7:] }} poller">🤖</div>
+          {% endif %}
+        </div>
+
+        <div class="info">
+          <a href="{{ job.url }}" target="_blank" rel="noopener" class="title">
+            {{ job.company or 'Unknown' }} <span class="dim">—</span> {{ job.title or '(no title)' }}
+          </a>
+          <div class="meta">
+            <span class="ats">{{ job.ats_platform or 'unknown ATS' }}</span>
+            <span class="age">{{ job.age_label }}</span>
+            <span class="status status-{{ job.status }}">{{ job.status }}</span>
+            {% if job.recommendation %}
+              <span class="rec rec-pill rec-{{ job.recommendation }}">{{ job.recommendation.replace('_', ' ') }}</span>
+            {% endif %}
+          </div>
+          {% if job.summary %}
+            <p class="summary">{{ job.summary }}</p>
+          {% endif %}
+          {% if job.strengths or job.gaps %}
+            <details class="analysis">
+              <summary>Analysis</summary>
+              {% if job.strengths %}
+                <h4>Strengths</h4>
+                <ul>{% for s in job.strengths %}<li>{{ s }}</li>{% endfor %}</ul>
+              {% endif %}
+              {% if job.gaps %}
+                <h4>Gaps</h4>
+                <ul>{% for g in job.gaps %}<li>{{ g }}</li>{% endfor %}</ul>
+              {% endif %}
+            </details>
+          {% endif %}
+        </div>
+
+        <div class="actions">
+          {% if job.status in ['discovered', 'ranked'] %}
+            <form method="post" action="/jobs/{{ job.id }}/apply">
+              <input type="hidden" name="branch" value="">
+              <button class="primary" title="Mark this position as one you've applied to (does not open the application page)">Mark applied</button>
+            </form>
+            <form method="post" action="/jobs/{{ job.id }}/dismiss">
+              <button>Dismiss</button>
+            </form>
+          {% elif job.status == 'applied' %}
+            <div class="branch">{{ job.branch or '—' }}</div>
+            <details class="outcome-form">
+              <summary>Outcome</summary>
+              <form method="post" action="/jobs/{{ job.id }}/outcome">
+                <label><input type="checkbox" name="referral" {{ 'checked' if job.referral }}> referral</label>
+                <label><input type="checkbox" name="callback" {{ 'checked' if job.callback }}> callback</label>
+                <label><input type="checkbox" name="ghosted" {{ 'checked' if job.ghosted }}> ghosted</label>
+                <label><input type="checkbox" name="rejected" {{ 'checked' if job.rejected }}> rejected</label>
+                <label><input type="checkbox" name="offer" {{ 'checked' if job.offer }}> offer</label>
+                <textarea name="notes" rows="2" placeholder="notes...">{{ job.notes or '' }}</textarea>
+                <button type="submit" class="primary">Save</button>
+              </form>
+            </details>
+          {% endif %}
+        </div>
+      </article>
+    {% endfor %}
+  </main>
+</body>
+</html>

--- a/job-board/job-store/urls.py
+++ b/job-board/job-store/urls.py
@@ -1,0 +1,98 @@
+"""URL helpers shared between the Flask app and the storage layer.
+
+Two distinct operations live here:
+
+- `canonicalize_url(url)`: clickable URL, normalized — drops tracking params,
+  strips trailing slash, and (for postings with `gh_jid`) keeps only that param.
+  This is what gets stored as `jobs.url` and what the user clicks on.
+
+- `compute_dedupe_key(url)`: opaque identifier shared by every URL form that
+  points at the same posting. For Greenhouse this is `gh:<jid>` regardless of
+  whether the URL points at the embed wrapper (e.g. `voxel51.com/jd?gh_jid=N`),
+  the boards-api host (`boards.greenhouse.io/<board>/jobs/N`), or the newer
+  `job-boards.greenhouse.io/...` form. Stored as `jobs.dedupe_key` and used as
+  the lookup key for the backend's "already scored?" guard and the badge.
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.parse
+
+
+# Tracking / referrer params that don't identify the posting itself.
+_TRACKING_PARAMS = {
+    "gh_src", "utm_source", "utm_medium", "utm_campaign", "utm_term",
+    "utm_content", "ref", "source", "lever-origin", "lever-source",
+}
+
+# Path patterns that carry a Greenhouse posting id directly in the URL path
+# rather than in a `gh_jid` query param.
+_GREENHOUSE_PATH = re.compile(r"^/[^/]+/jobs/(\d+)/?$")
+# Ashby direct-post URL: jobs.ashbyhq.com/<org>/<uuid>
+_ASHBY_PATH = re.compile(
+    r"^/[^/]+/([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})/?$",
+    re.IGNORECASE,
+)
+
+
+def canonicalize_url(url):
+    """Return a deduped, clickable form of `url`. See module docstring."""
+    if not url or url.startswith("manual-paste"):
+        return url
+    try:
+        u = urllib.parse.urlparse(url)
+    except Exception:
+        return url
+
+    params = urllib.parse.parse_qs(u.query, keep_blank_values=False)
+    gh_jid = params.get("gh_jid", [None])[0]
+    if gh_jid:
+        path = u.path.rstrip("/") or "/"
+        return f"{u.scheme}://{u.netloc}{path}?gh_jid={gh_jid}"
+
+    kept = [(k, v) for k, v in urllib.parse.parse_qsl(u.query, keep_blank_values=False)
+            if k not in _TRACKING_PARAMS]
+    new_query = urllib.parse.urlencode(kept)
+    path = u.path
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+    return urllib.parse.urlunparse((u.scheme, u.netloc, path, "", new_query, ""))
+
+
+def compute_dedupe_key(url):
+    """Return an opaque identifier that's the same across every URL form
+    pointing at one posting. See module docstring."""
+    if not url or url.startswith("manual-paste"):
+        return url
+    try:
+        u = urllib.parse.urlparse(url)
+    except Exception:
+        return url
+
+    # Greenhouse posting id wins over everything: it identifies the role
+    # regardless of which host serves the JD page.
+    params = urllib.parse.parse_qs(u.query, keep_blank_values=False)
+    gh_jid = params.get("gh_jid", [None])[0]
+    if not gh_jid and "greenhouse.io" in (u.netloc or ""):
+        m = _GREENHOUSE_PATH.match(u.path or "")
+        if m:
+            gh_jid = m.group(1)
+    if gh_jid:
+        return f"gh:{gh_jid}"
+
+    # Ashby: same idea. `ashby_jid` query param (embed wrapper on any host,
+    # e.g. www.ashbyhq.com/careers?ashby_jid=<uuid>) or UUID-on-path on
+    # jobs.ashbyhq.com.
+    ashby_jid = params.get("ashby_jid", [None])[0]
+    if not ashby_jid and (u.netloc or "") == "jobs.ashbyhq.com":
+        m = _ASHBY_PATH.match(u.path or "")
+        if m:
+            ashby_jid = m.group(1)
+    if ashby_jid:
+        # First UUID stanza is unique within Ashby; shorter key.
+        return f"ashby:{ashby_jid.split('-')[0]}"
+
+    # Fall through to canonical URL for non-Greenhouse/Ashby postings. Two
+    # URLs that differ only in tracking params / trailing slash converge here.
+    return canonicalize_url(url)


### PR DESCRIPTION
## Summary

Migrates the **job-board** runtime stack into this repo, where it belongs alongside the existing GitHub Actions. Three components, one PR:

| Component | What it does |
|---|---|
| `job-board/job-store/` | Flask + SQLite backend. Inbox UI, scoring endpoint, dedupe, ranking, company-targets CRUD. Holds the resume, the prompt, the schema, and the Anthropic key. |
| `job-board/job-store/poller.py` | Targeted-company poller CLI. Lives in the same Python package because it imports the backend's modules directly. |
| `job-board/firefox-plugin/` | MV3 extension. Extracts the JD from whatever page you're on, POSTs it to job-store, renders the score. |

Both the plugin and the poller POST job descriptions without a fit score. job-store calls Anthropic with the resume and the prompt, persists the analysis, returns the score. Neither the plugin nor the poller ever sees the API key.

See [`job-board/README.md`](https://github.com/dev-dull/job-search-automations/blob/add-job-board/job-board/README.md) for the architecture diagram and local-run instructions.

## What did not migrate (intentionally)

This is a public repo. The following stayed local:

- `jobs.db` and its WAL/SHM siblings (personal application history)
- The historical hunt CSV used to seed `outcomes`
- `.venv/` and `__pycache__/` (build artifacts)
- Any HAR captures from plugin debugging (may contain session cookies)
- The Anthropic API key

The running Flask instance backed by the resume repo is untouched. This PR is code-only and does not migrate the runtime.

## Fixes applied during migration

While moving the code I cleaned up three classes of issues:

**Hardcoded paths.** Two files assumed the original repo layout via `Path(__file__).parent.parent` defaults:
- `anthropic_client.py` now requires `RESUME_PATH` env var.
- `branch_high_priority.py` now requires `--resume-repo` flag or `RESUME_REPO` env var.

**Ashby slug consistency.** The plugin's `ATS_HOSTS` and the backend's adapter dispatch table disagreed about whether to use `ashby` or `ashbyhq`. Standardized on `ashby`. Dropped the alias from `adapters/__init__.py` and the stale defensive check in `branch_high_priority.py`. The host pattern `jobs.ashbyhq.com` is the real Ashby-hosted domain so URL regexes kept their `ashbyhq.com` substrings.

**Port references.** `app.py` and `poller.py` docstrings had a mix of `5050` and `5000`. Standardized on `5000` to match the actual `flask run` default and the plugin's default backend URL.

**Stale READMEs.** Both component READMEs still described the pre-server-side-scoring architecture (plugin calling Anthropic directly, `host_permissions` for `api.anthropic.com`, the old port). Rewrote both to match the current shape.

## Test plan

- [ ] `pip install -r job-board/job-store/requirements.txt`
- [ ] `export ANTHROPIC_API_KEY=... RESUME_PATH=~/wip/resume/resume_details.yaml`
- [ ] `flask --app job-board/job-store/app run --port 5000` -> inbox loads at `127.0.0.1:5000`
- [ ] `python job-board/job-store/poller.py --dry-run` -> previews without writing
- [ ] Load `job-board/firefox-plugin/manifest.json` as a temporary add-on in Firefox
- [ ] Set backend URL in options page to `http://127.0.0.1:5000`, click Test -> shows "Reachable"
- [ ] Visit a Greenhouse, Ashby, Lever, or Workday posting -> popup scores it and the score appears in the inbox
- [ ] Click the briefcase icon on a previously-scored URL -> badge shows the cached score

## Follow-ups

After merge, I will file issues for:

- Deployment: Dockerfile, Helm chart, CronJob for the poller, PVC for the SQLite DB, Secret management, Ingress + TLS
- Adapters: iCIMS adapter implementation, refresh-posted-at, title drift detection, URL canonicalization edge cases, Workday probe-at-create
- Plugin: Phase 4 cleanup (drop legacy `fit_score`-in-body code path), backend-offline error handling
- Job-store hygiene: auto-ghost old applications, Apply button creates a resume-repo branch in one click, AI deny-list for false-positive employers

The corresponding placeholder issues currently filed on `dev-dull/resume` (#20-#26) will be closed with pointers to the new ones here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)