### PR TITLE
Make desirability scoring pace-aware; emit pace_signals

### DIFF
--- a/job-board/job-store/anthropic_client.py
+++ b/job-board/job-store/anthropic_client.py
@@ -89,11 +89,16 @@ SYSTEM_INSTRUCTIONS = (
 _DESIRABILITY_PROPERTIES: dict[str, Any] = {
     "desirability_score": {
         "type": "integer",
-        "description": "A score between 1 and 100 for how well this role matches the kind of work the candidate says they want (see their stated preferences), independent of whether they are qualified for it.",
+        "description": "A score between 1 and 100 for how well this role matches the kind of work the candidate says they want (see their stated preferences), independent of whether they are qualified for it. Weigh the candidate's sustainable-pace preferences heavily: lower the score for red-flag intensity signals and raise it for green-flag structural-rest signals.",
     },
     "desirability_explanation": {
         "type": "string",
-        "description": "A brief explanation of desirability_score, no longer than 150 words.",
+        "description": "A brief explanation of desirability_score, no longer than 150 words. Note any pace/sustainability factors that moved the score.",
+    },
+    "pace_signals": {
+        "type": "array",
+        "items": {"type": "string"},
+        "description": "Specific pace/sustainability tells found in the job description or company, each prefixed with 'RED: ' (intensity/grind signal) or 'GREEN: ' (sustainable-pace signal), per the candidate's sustainable-pace preferences. Empty array if none are present.",
     },
 }
 
@@ -102,7 +107,7 @@ def _schema_with_desirability() -> dict[str, Any]:
     """FIT_SCHEMA plus the desirability fields (used when preferences exist)."""
     s = json.loads(json.dumps(FIT_SCHEMA))      # deep copy
     s["properties"].update(_DESIRABILITY_PROPERTIES)
-    s["required"] = s["required"] + ["desirability_score", "desirability_explanation"]
+    s["required"] = s["required"] + ["desirability_score", "desirability_explanation", "pace_signals"]
     return s
 
 
@@ -183,8 +188,9 @@ def _format_user_message(*, description: str, url: str | None,
     ]
     if has_preferences:
         fields += [
-            "- desirability_score: a score between 1 and 100 for how well this role matches the kind of work the candidate says they want (see <preferences> in the system context), independent of whether they are qualified for it.",
-            "- desirability_explanation: a brief explanation of desirability_score, no longer than 150 words.",
+            "- desirability_score: a score between 1 and 100 for how well this role matches the kind of work the candidate says they want (see <preferences> in the system context), independent of whether they are qualified for it. Weigh the candidate's sustainable-pace preferences heavily: reduce the score for red-flag intensity signals (e.g. 'fast-paced', 'ship big things every week', on-call as a core duty, hypergrowth burn) and raise it for green-flag structural-rest signals (e.g. minimum/mandatory PTO, profitability, genuinely async/remote-first).",
+            "- desirability_explanation: a brief explanation of desirability_score, no longer than 150 words; note any pace/sustainability factors that moved the score.",
+            "- pace_signals: a list of the specific pace/sustainability tells from the posting, each prefixed with 'RED: ' or 'GREEN: ' per the candidate's sustainable-pace preferences; an empty list if none.",
         ]
     instruction = "\n".join([
         "Compare the resume and job description with the goal of helping the candidate tailor their resume for the position.",

--- a/job-board/job-store/tests/test_anthropic_schema.py
+++ b/job-board/job-store/tests/test_anthropic_schema.py
@@ -1,0 +1,61 @@
+"""Guards the server-side desirability schema + prompt (the has_preferences
+path), including the pace_signals field.
+
+The scorer imports the `anthropic` SDK at module load; it isn't in the host test
+env, so we stub it when absent (these tests only exercise the pure schema/prompt
+builders, never the API).
+"""
+
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:  # use the real SDK when present (container/CI), else a stub
+    import anthropic  # noqa: F401
+except Exception:
+    _stub = types.ModuleType("anthropic")
+    _stub.Anthropic = object
+    sys.modules["anthropic"] = _stub
+
+import anthropic_client as ac  # noqa: E402
+
+_DESIRABILITY_FIELDS = ("desirability_score", "desirability_explanation", "pace_signals")
+
+
+def _prompt(has_preferences):
+    return ac._format_user_message(
+        description="x" * 200, url=None, title=None, ats_platform=None,
+        growth_keywords="", has_preferences=has_preferences)
+
+
+class DesirabilitySchemaTest(unittest.TestCase):
+    def test_fields_present_and_required(self):
+        s = ac._schema_with_desirability()
+        for k in _DESIRABILITY_FIELDS:
+            self.assertIn(k, s["properties"], k)
+            self.assertIn(k, s["required"], k)
+        self.assertEqual(s["properties"]["pace_signals"]["type"], "array")
+        # closed schema: structured output must match exactly
+        self.assertIs(s.get("additionalProperties"), False)
+
+    def test_base_fit_schema_not_mutated(self):
+        ac._schema_with_desirability()  # deep-copies; must not touch the shared base
+        self.assertNotIn("pace_signals", ac.FIT_SCHEMA["properties"])
+        self.assertNotIn("desirability_score", ac.FIT_SCHEMA["properties"])
+
+    def test_prompt_and_schema_stay_in_lockstep(self):
+        p = _prompt(has_preferences=True)
+        for k in _DESIRABILITY_FIELDS:
+            self.assertIn(f"{k}:", p, k)
+
+    def test_no_preferences_path_is_unchanged(self):
+        p = _prompt(has_preferences=False)
+        self.assertNotIn("desirability", p)
+        self.assertNotIn("pace_signals", p)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Extends the desirability axis so it weighs sustainable pace, per a strategy worked out in the resume/job-search session. The scorer now:

- **Weighs pace in `desirability_score`** — the prompt + schema tell the model to lower the score for red-flag intensity signals and raise it for green-flag structural-rest signals.
- **Emits `pace_signals`** — an array of the specific tells found in the posting, each prefixed `RED: ` or `GREEN: `, so the pace judgment is explainable, not invisible.

## Why here / scope

The red/green signal *definitions* live in the candidate's preferences file (resume repo: `job-preferences.md`, committed separately — new "Sustainable pace" section), which this scorer already reads verbatim into the desirability prompt. This PR is just the scorer-side plumbing.

Design notes for review:
- Changes are confined to the **desirability (`has_preferences`) path**. The server-only `_DESIRABILITY_PROPERTIES` block is not part of the Firefox plugin's `FIT_SCHEMA` lockstep, so `popup.js` is untouched.
- `pace_signals` rides along in `analysis_json` (only `desirability_score` is a dedicated column), so **no DB migration** is needed.
- Ranking math is unchanged: `desirability_score` already blends into `rank_score` at `DESIRABILITY_WEIGHT`, so pace-aware desirability makes rank pace-aware automatically.

## For the reviewing session to consider / tweak
- Whether to surface `pace_signals` in the templates (`index.html`) — currently captured in data only.
- Whether pace deserves its *own* weighted rank factor rather than riding inside `desirability_score`.
- Re-scoring existing rows via `rescore.py` to backfill `pace_signals`.
- Deploy: the homelab job-store needs a redeploy to pick up this change, and `PREFERENCES_PATH` must point at the updated `job-preferences.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)