### PR TITLE
candidate-agent: phase 2 — session recording, durable limits, admin surface

### DIFF
--- a/candidate-agent/Dockerfile
+++ b/candidate-agent/Dockerfile
@@ -28,13 +28,17 @@ FROM python:3.13-slim AS runtime
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PATH="/opt/venv/bin:$PATH" \
-    HOME=/tmp
+    HOME=/tmp \
+    AGENT_DB_PATH=/data/agent.db
 COPY --from=build /opt/venv /opt/venv
 WORKDIR /app
 COPY *.py ./
 COPY templates ./templates
-RUN useradd --uid 1000 --no-create-home agent
+RUN useradd --uid 1000 --no-create-home agent && \
+    mkdir -p /data && chown 1000 /data
 USER 1000
+# Phase-2 DB lives on a mounted volume (rootfs is read-only in k8s).
+VOLUME /data
 EXPOSE 8000
 # FTS5 assert + single worker (SQLite one-writer rule, phase 2).
 CMD ["sh", "-c", "python -c \"import sqlite3; sqlite3.connect(':memory:').execute('CREATE VIRTUAL TABLE t USING fts5(c)')\" && exec uvicorn app:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips '*'"]

--- a/candidate-agent/PLAN.md
+++ b/candidate-agent/PLAN.md
@@ -418,6 +418,12 @@ Definition of done for phase 1:
 
 ## Phase 2 — session recording & analytics
 
+**Status 2026-08-10: implemented** (store.py: codes/sessions/messages/counters;
+recording wired through all three surfaces; durable rate/budget counters;
+disclosure lines; mint_code.py + report.py; /admin/summary.json behind
+ADMIN_TOKEN; DB volume + fsGroup in the image/chart). Retrieval rung 2
+remains deliberately unbuilt — the corpus hasn't outgrown full context.
+
 Everything phase 1 keeps in memory becomes durable and attributable:
 
 - SQLite (`AGENT_DB_PATH`, WAL, generous busy timeout — a lesson the

--- a/candidate-agent/README.md
+++ b/candidate-agent/README.md
@@ -43,12 +43,18 @@ maple-K7RT-hazel  | Acme Corp   | expires=2026-08-30
 birch-Q2ZX-otter  | Beta Search | url_auth | note=met at conf
 ```
 
+Phase 2 adds a second way to manage codes: `python3 mint_code.py "Acme
+Recruiting" --days 14 [--url-auth]` mints a code directly in the database
+(and `--revoke <code>` revokes it). File codes and CLI codes coexist — the
+file stays authoritative for its own entries (delete a line to revoke), and
+the sync never touches CLI-minted rows.
+
 `url_auth` lets the code travel in URLs (`/c/<code>` fetch surface and the
 `/mcp/<code>` claude.ai form) — issue it deliberately and prefer shorter
 expiries there. Revoke by deleting the line (or adding `revoked`); revocation
 takes effect within your content-sync interval + ~1 minute, including for
 already-open browser sessions. All counters (rate, budget, failed-attempt
-limits) are in-memory phase-1: they reset on restart.
+limits) are stored in the phase-2 database and survive restarts.
 
 ## Seeding your corpus
 
@@ -75,6 +81,33 @@ left as values. Whatever fronts it must terminate TLS, pass streaming
 responses unbuffered, and be reachable from the public internet — see
 PLAN.md's deployment requirements. Run single-process only
 (`uvicorn --workers 1`; the Dockerfile already does).
+
+## Session recording (phase 2)
+
+Every conversation is recorded to SQLite at `AGENT_DB_PATH` (default
+`/data/agent.db` in the container — mount a volume): sessions carry the
+surface (`web` | `mcp` | `fetch`), IP, browser User-Agent, and — for MCP —
+the connecting client's name/version from the `initialize` handshake;
+messages carry full transcripts with per-message token counts and cost.
+Honest semantics: a `web` session is a real conversation; an `mcp` session
+is a transport session (best-effort grouping); a `fetch` session is one
+code's traffic for one UTC day. Both chat surfaces and the MCP tool
+description disclose that conversations are recorded.
+
+Reading it:
+
+```
+python3 report.py                        # per-code rollup: sessions, messages, cost, last seen
+python3 report.py --code <code>          # sessions for one code
+python3 report.py --session <session-id> # full transcript
+```
+
+`GET /admin/summary.json` returns the same rollup over HTTP when
+`ADMIN_TOKEN` is set (send it as `X-Admin-Token`); it 404s when unset.
+
+You are storing conversations with identifiable metadata — treat the DB as
+personal data: keep it on the private side, and say so to the people talking
+to the agent (the built-in disclosure lines do).
 
 ## Development
 

--- a/candidate-agent/app.py
+++ b/candidate-agent/app.py
@@ -274,7 +274,14 @@ def admin_summary(request: Request):
     if not token:
         return JSONResponse({"error": "admin disabled (ADMIN_TOKEN unset)"},
                             status_code=404)
-    if request.headers.get("x-admin-token") != token:
+    # Same failed-attempt limiting as every other credential path — this is
+    # the endpoint that returns the personal-data rollup — plus a
+    # constant-time compare.
+    ip = _client_ip(request)
+    if not limiter.attempts_ok(ip):
+        return JSONResponse({"error": "too many attempts"}, status_code=429)
+    if not secrets.compare_digest(request.headers.get("x-admin-token", ""), token):
+        limiter.record_failed_attempt(ip)
         return JSONResponse({"error": "unauthorized"}, status_code=401)
     return JSONResponse({"codes": db.summary()})
 

--- a/candidate-agent/app.py
+++ b/candidate-agent/app.py
@@ -29,6 +29,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Str
 import codes as codes_mod
 import corpus as corpus_mod
 import engine as engine_mod
+import store as store_mod
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
 log = logging.getLogger("candidate-agent")
@@ -37,9 +38,16 @@ CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "the candidate")
 SESSION_TTL_S = 12 * 3600
 
 corpus = corpus_mod.Corpus()
+db = store_mod.Store()
 table = codes_mod.CodeTable()
-limiter = codes_mod.Limiter()
-engine = engine_mod.Engine(corpus, limiter)
+table.attach_store(db)
+limiter = store_mod.DurableLimiter(db)          # restart-proof (phase 2)
+engine = engine_mod.Engine(corpus, limiter, recorder=db.record_exchange)
+
+# Best-effort MCP client identity: clientInfo arrives only on `initialize`,
+# before the server assigns a session id, so remember the last client seen
+# per code and attach it when the session row is first touched.
+_mcp_clients: dict[str, tuple[str, str]] = {}
 
 # In-memory browser sessions: sid -> dict(code, history, created, last)
 _sessions: dict[str, dict] = {}
@@ -82,7 +90,8 @@ mcp = FastMCP(
     instructions=(
         "This server answers questions about one job candidate on their "
         "behalf, grounded in their published corpus. Ask natural-language "
-        "questions with ask_candidate_agent."),
+        "questions with ask_candidate_agent. Conversations are recorded and "
+        "reviewed by the candidate."),
 )
 
 
@@ -109,15 +118,19 @@ def _mcp_session_key(code: codes_mod.Code) -> str:
 def ask_candidate_agent(question: str) -> str:
     """Ask a natural-language question about the candidate — their employment
     history, skills, projects, or interests. Answers are grounded in the
-    candidate's published corpus."""
+    candidate's published corpus. Conversations are recorded."""
     code = _mcp_code()
     if code is None:
         return "This connection is not authorized. Check the access code."
     if not limiter.allow_request(code.code):
         return "Rate limit reached for this access code; try again later."
     corpus.check_reload()
-    return engine.answer(code.code, question,
-                         continuity_key=_mcp_session_key(code))
+    skey = _mcp_session_key(code)
+    client = _mcp_clients.get(code.code, (None, None))
+    db.touch_session(skey, code.code, "mcp",
+                     client_name=client[0], client_version=client[1])
+    return engine.answer(code.code, question, continuity_key=skey,
+                         session_ref=skey)
 
 
 @mcp.tool
@@ -206,6 +219,10 @@ class _InitializePeek:
                     info = payload.get("params", {}).get("clientInfo", {})
                     log.info("mcp initialize: code=%s client=%s/%s",
                              self._code.label, info.get("name"), info.get("version"))
+                    _mcp_clients[self._code.code] = (
+                        info.get("name"), info.get("version"))
+                    if len(_mcp_clients) > 200:
+                        _mcp_clients.pop(next(iter(_mcp_clients)))
                 except Exception:                        # noqa: BLE001
                     pass
         return message
@@ -249,6 +266,17 @@ def healthz():
     return {"ok": True}
 
 
+@app.get("/admin/summary.json")
+def admin_summary(request: Request):
+    token = os.environ.get("ADMIN_TOKEN")
+    if not token:
+        return JSONResponse({"error": "admin disabled (ADMIN_TOKEN unset)"},
+                            status_code=404)
+    if request.headers.get("x-admin-token") != token:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    return JSONResponse({"codes": db.summary()})
+
+
 @app.get("/robots.txt", response_class=PlainTextResponse)
 def robots():
     # The gate is the code, not obscurity — but no reason to invite crawlers.
@@ -282,7 +310,8 @@ def fetch_landing(code: str, request: Request):
         f"Fetch: {base}/c/{code}/ask?q=<url-encoded question>\n\n"
         "Ask one concise question per request (keep the URL short). You may "
         "ask follow-ups; recent questions from this access code are "
-        "remembered briefly. Responses are plain markdown.\n\n"
+        "remembered briefly. Responses are plain markdown. Questions and "
+        "answers are recorded and reviewed by the candidate.\n\n"
         "## Profile card\n\n" + corpus.profile_summary() + "\n",
         headers=_FETCH_HEADERS, media_type="text/markdown")
 
@@ -300,8 +329,13 @@ def fetch_ask(code: str, request: Request, q: str = ""):
         return PlainTextResponse("Rate limit reached; try again later.",
                                  status_code=429, headers=_FETCH_HEADERS)
     corpus.check_reload()
+    day = time.strftime("%Y-%m-%d", time.gmtime())
+    skey = f"fetch:{c.code}:{day}"           # a fetch 'session' = code + UTC day
+    db.touch_session(skey, c.code, "fetch", ip=_client_ip(request),
+                     user_agent=request.headers.get("user-agent"))
     answer = engine.answer(c.code, q.strip(),
-                           continuity_key=f"fetch:{c.code}")
+                           continuity_key=f"fetch:{c.code}",
+                           session_ref=skey)
     return PlainTextResponse(answer, headers=_FETCH_HEADERS,
                              media_type="text/markdown")
 
@@ -333,6 +367,8 @@ async def start_session(request: Request):
         limiter.record_failed_attempt(ip)
         return _expired_page(table.status(raw))
     sid = secrets.token_urlsafe(32)         # fresh id at code entry (fixation)
+    db.touch_session(f"web:{sid}", raw, "web", ip=ip,
+                     user_agent=request.headers.get("user-agent"))
     with _sessions_lock:
         _sessions[sid] = {"code": raw, "history": [],
                           "created": time.time(), "last": time.time()}
@@ -380,10 +416,13 @@ async def chat(request: Request):
     sess["last"] = time.time()
     history = list(sess["history"])
 
+    sid = request.cookies.get("agent_session")
+
     def generate():
         chunks = []
         try:
-            for text in engine.stream_answer(c.code, history, question):
+            for text in engine.stream_answer(c.code, history, question,
+                                             session_ref=f"web:{sid}"):
                 chunks.append(text)
                 yield f"data: {json.dumps({'text': text})}\n\n"
         except Exception as e:                           # noqa: BLE001

--- a/candidate-agent/app.py
+++ b/candidate-agent/app.py
@@ -108,7 +108,9 @@ def _mcp_code(request: Request | None = None) -> codes_mod.Code | None:
 def _mcp_session_key(code: codes_mod.Code) -> str:
     try:
         from fastmcp.server.dependencies import get_http_headers
-        sid = get_http_headers().get("mcp-session-id", "")
+        # include_all: FastMCP strips MCP-transport headers by default, and
+        # mcp-session-id is exactly the one we need for session grouping.
+        sid = get_http_headers(include_all=True).get("mcp-session-id", "")
     except Exception:                                    # noqa: BLE001
         sid = ""
     return f"mcp:{code.code}:{sid}"

--- a/candidate-agent/codes.py
+++ b/candidate-agent/codes.py
@@ -76,13 +76,21 @@ def _parse_line(line: str) -> Code | None:
 
 
 class CodeTable:
-    """Loads the code file, reloading when its mtime changes."""
+    """Loads the code file, reloading when its mtime changes. With a store
+    attached (phase 2), the file is synced into the DB on reload and lookups
+    read from the DB — so CLI-minted codes work alongside file codes while
+    file-removal revocation keeps its phase-1 semantics."""
 
     def __init__(self, path: str | None = None):
         self.path = path or os.environ.get("ACCESS_CODES_PATH")
         self._mtime: float | None = None
         self._codes: dict[str, Code] = {}
         self._lock = threading.Lock()
+        self._store = None
+
+    def attach_store(self, store) -> None:
+        self._store = store
+        self._mtime = None          # force a resync on next lookup
 
     def _refresh(self) -> None:
         if not self.path or not os.path.exists(self.path):
@@ -99,6 +107,19 @@ class CodeTable:
         with self._lock:
             self._codes = table
             self._mtime = mtime
+        if self._store is not None:
+            self._store.sync_codes_from_file(list(table.values()))
+
+    def _get(self, code: str) -> Code | None:
+        if self._store is not None:
+            row = self._store.get_code(code)
+            if row is None:
+                return None
+            return Code(code=row["code"], label=row["label"],
+                        expires=row["expires"], url_auth=bool(row["url_auth"]),
+                        revoked=bool(row["revoked"]), note=row["note"])
+        with self._lock:
+            return self._codes.get(code)
 
     def lookup(self, code: str | None) -> Code | None:
         """The usable Code for this string, else None. Revoked/expired/absent
@@ -106,8 +127,7 @@ class CodeTable:
         if not code:
             return None
         self._refresh()
-        with self._lock:
-            c = self._codes.get(code.strip())
+        c = self._get(code.strip())
         return c if c and c.usable() else None
 
     def status(self, code: str | None) -> str:
@@ -115,8 +135,7 @@ class CodeTable:
         if not code:
             return "unknown"
         self._refresh()
-        with self._lock:
-            c = self._codes.get(code.strip())
+        c = self._get(code.strip())
         if c is None:
             return "unknown"
         return "ok" if c.usable() else "expired"

--- a/candidate-agent/docker-compose.example.yaml
+++ b/candidate-agent/docker-compose.example.yaml
@@ -20,6 +20,12 @@ services:
       ACCESS_CODES_PATH: /content/codes.txt
       REDACTION_DENYLIST_PATH: /content/denylist.txt
       CONTACT_EMAIL: you@example.com
+      AGENT_DB_PATH: /data/agent.db      # phase 2: sessions/transcripts/budgets
+      # ADMIN_TOKEN: set-to-enable /admin/summary.json
     volumes:
       - ./private:/content:ro
+      - agent-data:/data
     restart: unless-stopped
+
+volumes:
+  agent-data:

--- a/candidate-agent/engine.py
+++ b/candidate-agent/engine.py
@@ -78,9 +78,12 @@ Rules, non-negotiable:
 
 
 class Engine:
-    def __init__(self, corpus, limiter):
+    def __init__(self, corpus, limiter, recorder=None):
         self.corpus = corpus
         self.limiter = limiter
+        # recorder(session_ref, question, answer, usage, cost_usd) — phase-2
+        # transcript hook; None disables recording.
+        self.recorder = recorder
         self._client = None
         self._continuity: dict[str, tuple[float, list]] = {}
         self._lock = threading.Lock()
@@ -123,17 +126,27 @@ class Engine:
                 oldest = min(self._continuity, key=lambda k: self._continuity[k][0])
                 del self._continuity[oldest]
 
-    def _log_usage(self, code: str, usage) -> None:
+    def _log_usage(self, code: str, usage) -> float:
         cost = usage_cost_usd(usage)
         self.limiter.record_spend(code, cost)
         get = lambda k: getattr(usage, k, 0) or 0   # noqa: E731
         log.info("usage code=%s in=%d cache_read=%d cache_write=%d out=%d cost=$%.4f",
                  code, get("input_tokens"), get("cache_read_input_tokens"),
                  get("cache_creation_input_tokens"), get("output_tokens"), cost)
+        return cost
+
+    def _record(self, session_ref, question, answer, usage, cost) -> None:
+        if self.recorder is None or session_ref is None:
+            return
+        try:
+            self.recorder(session_ref, question, answer, usage, cost)
+        except Exception as e:                       # noqa: BLE001
+            log.error("transcript recording failed (answer still served): %s", e)
 
     # -- entry points -------------------------------------------------------
 
-    def answer(self, code: str, question: str, continuity_key: str | None = None) -> str:
+    def answer(self, code: str, question: str, continuity_key: str | None = None,
+               session_ref: str | None = None) -> str:
         """Non-streaming answer (MCP tool + fetch surface)."""
         if not self.limiter.budget_ok(code):
             return ("This agent's daily budget is exhausted. Please try again "
@@ -143,14 +156,16 @@ class Engine:
         response = self._anthropic().messages.create(
             model=MODEL, max_tokens=MAX_ANSWER_TOKENS,
             system=self._system(), messages=messages)
-        self._log_usage(code, response.usage)
+        cost = self._log_usage(code, response.usage)
         text = "".join(b.text for b in response.content
                        if getattr(b, "type", None) == "text")
         if continuity_key:
             self._remember(continuity_key, question, text)
+        self._record(session_ref, question, text, response.usage, cost)
         return text
 
-    def stream_answer(self, code: str, history: list, question: str):
+    def stream_answer(self, code: str, history: list, question: str,
+                      session_ref: str | None = None):
         """Streaming generator for the browser surface. Yields text chunks;
         the caller owns history persistence."""
         if not self.limiter.budget_ok(code):
@@ -158,10 +173,13 @@ class Engine:
                    "tomorrow or contact the candidate directly.")
             return
         messages = history + [{"role": "user", "content": question}]
+        chunks = []
         with self._anthropic().messages.stream(
                 model=MODEL, max_tokens=MAX_ANSWER_TOKENS,
                 system=self._system(), messages=messages) as stream:
             for text in stream.text_stream:
+                chunks.append(text)
                 yield text
             final = stream.get_final_message()
-        self._log_usage(code, final.usage)
+        cost = self._log_usage(code, final.usage)
+        self._record(session_ref, question, "".join(chunks), final.usage, cost)

--- a/candidate-agent/helm/templates/deployment.yaml
+++ b/candidate-agent/helm/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app.kubernetes.io/name: candidate-agent
     spec:
+      securityContext:
+        fsGroup: 1000          # PVC mounts writable by the non-root app user
       {{- if .Values.contentSync.git.enabled }}
       initContainers:
         - name: clone-content
@@ -52,6 +54,13 @@ spec:
               value: {{ $v | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.adminTokenSecret.name }}
+            - name: ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.adminTokenSecret.name }}
+                  key: {{ .Values.adminTokenSecret.key }}
+            {{- end }}
           readinessProbe:
             httpGet: { path: /healthz, port: 8000 }
             initialDelaySeconds: 3
@@ -65,6 +74,9 @@ spec:
             allowPrivilegeEscalation: false
           volumeMounts:
             - { name: tmp, mountPath: /tmp }
+            {{- if .Values.persistence.enabled }}
+            - { name: data, mountPath: /data }
+            {{- end }}
             {{- if .Values.contentSync.git.enabled }}
             - { name: content, mountPath: /content, readOnly: true }
             {{- end }}
@@ -97,6 +109,11 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-data
+        {{- end }}
         {{- if .Values.contentSync.git.enabled }}
         - name: content
           emptyDir: {}

--- a/candidate-agent/helm/templates/pvc.yaml
+++ b/candidate-agent/helm/templates/pvc.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-data
+  annotations:
+    helm.sh/resource-policy: keep   # transcripts/budgets outlive an uninstall
 spec:
   accessModes: [ReadWriteOnce]
   {{- if .Values.persistence.storageClassName }}

--- a/candidate-agent/helm/templates/pvc.yaml
+++ b/candidate-agent/helm/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-data
+spec:
+  accessModes: [ReadWriteOnce]
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/candidate-agent/helm/values.yaml
+++ b/candidate-agent/helm/values.yaml
@@ -35,6 +35,17 @@ ingress:
   tls: []                    # standard ingress TLS blocks
   annotations: {}
 
+# Phase-2 session/transcript DB (AGENT_DB_PATH=/data/agent.db in the image).
+persistence:
+  enabled: true
+  size: 1Gi
+  storageClassName: ""      # cluster default when empty
+
+# Enables GET /admin/summary.json when set (via an existing Secret).
+adminTokenSecret:
+  name: ""                  # e.g. candidate-agent-admin
+  key: token
+
 resources:
   requests: { cpu: 100m, memory: 128Mi }
   limits: { cpu: 500m, memory: 512Mi }

--- a/candidate-agent/mint_code.py
+++ b/candidate-agent/mint_code.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Mint (or revoke) access codes directly in the phase-2 database.
+
+The flat file at ACCESS_CODES_PATH remains fully supported — file-sourced
+codes sync on reload and revoke by deleting the line. This CLI manages
+DB-native ('cli') codes, which the file sync never touches.
+
+    python3 mint_code.py "Acme Recruiting"                  # 30-day code
+    python3 mint_code.py "Beta Search" --days 14 --url-auth
+    python3 mint_code.py --revoke maple-K7RT-hazel
+
+Run where AGENT_DB_PATH points at the live database (e.g. inside the
+container/pod, or against the mounted volume).
+"""
+
+from __future__ import annotations
+
+import argparse
+import secrets
+import sys
+from datetime import date, timedelta
+
+import store
+
+WORDS = ("maple birch cedar aspen alder hazel rowan willow juniper laurel "
+         "otter heron finch marten osprey plover raven teal wren ibis").split()
+
+
+def generate_code() -> str:
+    a, b = secrets.choice(WORDS), secrets.choice(WORDS)
+    mid = "".join(secrets.choice("ABCDEFGHJKMNPQRSTUVWXYZ23456789") for _ in range(4))
+    return f"{a}-{mid}-{b}"
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("label", nargs="?", help="who this code is issued to")
+    ap.add_argument("--days", type=int, default=30, help="expiry (default 30)")
+    ap.add_argument("--url-auth", action="store_true",
+                    help="allow URL-carried use (/c/<code>, /mcp/<code>)")
+    ap.add_argument("--note", default="")
+    ap.add_argument("--revoke", metavar="CODE",
+                    help="revoke a CLI-minted code instead of minting")
+    args = ap.parse_args(argv)
+
+    db = store.Store()
+    if args.revoke:
+        if db.revoke_cli_code(args.revoke):
+            print(f"revoked {args.revoke}")
+            return 0
+        print(f"no CLI-minted code {args.revoke!r} (file codes revoke by "
+              f"deleting their line)", file=sys.stderr)
+        return 1
+
+    if not args.label:
+        ap.error("label is required when minting")
+    code = generate_code()
+    expires = (date.today() + timedelta(days=args.days)).isoformat()
+    db.upsert_cli_code(code, args.label, expires, args.url_auth, args.note)
+    print(f"{code}   ({args.label}, expires {expires}"
+          f"{', url_auth' if args.url_auth else ''})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/candidate-agent/report.py
+++ b/candidate-agent/report.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Read-only reporting over the phase-2 database (the pre-UI admin surface).
+
+    python3 report.py                        # per-code rollup
+    python3 report.py --code <code>          # sessions for one code
+    python3 report.py --session <session-id> # full transcript
+
+Run where AGENT_DB_PATH points at the live database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import store
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--code", help="list sessions for this code")
+    ap.add_argument("--session", help="print the transcript for this session id")
+    args = ap.parse_args(argv)
+    db = store.Store()
+
+    if args.session:
+        for m in db.transcript(args.session):
+            who = "EMPLOYER" if m["role"] == "user" else "AGENT   "
+            cost = f"  (${m['cost_usd']:.4f})" if m["cost_usd"] else ""
+            print(f"[{m['created_at']}] {who}{cost}\n{m['content']}\n")
+        return 0
+
+    if args.code:
+        for s in db.sessions_for_code(args.code):
+            print(f"{s['id']}\n  surface={s['surface']} "
+                  f"client={s['client_name'] or '-'}/{s['client_version'] or '-'} "
+                  f"ip={s['ip'] or '-'}\n  {s['started_at']} -> {s['last_active_at']}")
+        return 0
+
+    rows = db.summary()
+    if not rows:
+        print("No codes in the database yet.")
+        return 0
+    print(f"{'code':<22} {'label':<20} {'src':<5} {'sess':>4} {'msgs':>5} "
+          f"{'cost':>8}  last seen")
+    for r in rows:
+        flag = " (REVOKED)" if r["revoked"] else ""
+        print(f"{r['code']:<22} {r['label'][:19]:<20} {r['source']:<5} "
+              f"{r['sessions']:>4} {r['messages']:>5} "
+              f"${r['cost_usd']:>7.2f}  {r['last_seen'] or '-'}{flag}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/candidate-agent/store.py
+++ b/candidate-agent/store.py
@@ -89,6 +89,17 @@ class Store:
         conn.commit()
         conn.execute("PRAGMA journal_mode = WAL")
         conn.commit()
+        # Sweep stale counters on startup: bounded table growth, and expired
+        # fail:<ip> rows stop retaining IPs beyond their window (the README's
+        # own personal-data guidance applies to us too). Window numbers are
+        # only comparable within one window size, so prune per kind.
+        import time as _time
+        hour_w, day_w = int(_time.time() // 3600), int(_time.time() // 86400)
+        conn.execute("DELETE FROM counters WHERE (key LIKE 'req:%' OR "
+                     "key LIKE 'fail:%') AND window < ?", (hour_w,))
+        conn.execute("DELETE FROM counters WHERE key LIKE 'spend:%' "
+                     "AND window < ?", (day_w,))
+        conn.commit()
         conn.close()
 
     def _conn(self) -> sqlite3.Connection:
@@ -99,15 +110,23 @@ class Store:
     # -- codes --------------------------------------------------------------
 
     def sync_codes_from_file(self, parsed_codes: list) -> None:
-        """Replace all source='file' rows to match the file exactly. CLI-minted
-        rows are untouched, preserving both minting paths."""
+        """Sync source='file' rows to the file WITHOUT deleting history: rows
+        absent from the file are tombstoned (revoked), not removed, so a code
+        revoked by deleting its line keeps its sessions/cost in every rollup —
+        revocation is every code's normal end state and attribution is the
+        point of phase 2. Re-adding a line un-revokes (the file stays
+        authoritative); created_at survives resyncs. CLI-minted rows are
+        untouched, preserving both minting paths."""
         with self._lock, self._conn() as conn:
-            conn.execute("DELETE FROM codes WHERE source = 'file'")
+            conn.execute("UPDATE codes SET revoked = 1 WHERE source = 'file'")
             for c in parsed_codes:
                 conn.execute(
-                    "INSERT OR REPLACE INTO codes "
+                    "INSERT INTO codes "
                     "(code, label, expires, url_auth, revoked, note, source, created_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, 'file', ?)",
+                    "VALUES (?, ?, ?, ?, ?, ?, 'file', ?) "
+                    "ON CONFLICT(code) DO UPDATE SET label=excluded.label, "
+                    "expires=excluded.expires, url_auth=excluded.url_auth, "
+                    "revoked=excluded.revoked, note=excluded.note, source='file'",
                     (c.code, c.label, c.expires, int(c.url_auth),
                      int(c.revoked), c.note, _now()))
 
@@ -166,7 +185,9 @@ class Store:
 
     def record_exchange(self, session_id: str, question: str, answer: str,
                         usage=None, cost_usd: float = 0.0) -> None:
-        get = (usage.get if isinstance(usage, dict)
+        # Both branches must default missing keys to 0 — the token columns are
+        # NOT NULL, and a None here would silently drop the whole exchange.
+        get = ((lambda k, d=0: usage.get(k, d) or 0) if isinstance(usage, dict)
                else lambda k, d=0: getattr(usage, k, d) or 0) if usage else lambda k, d=0: 0
         now = _now()
         with self._lock, self._conn() as conn:

--- a/candidate-agent/store.py
+++ b/candidate-agent/store.py
@@ -1,0 +1,267 @@
+"""Phase-2 persistence: codes, sessions, transcripts, durable counters.
+
+SQLite at AGENT_DB_PATH (default ./agent.db — the container should point this
+at a mounted volume). WAL + generous busy timeout, single-process serving
+(uvicorn --workers 1) — the same one-writer discipline as job-store, learned
+the hard way there.
+
+Code-table semantics (the phase-1 file stays first-class):
+- Rows synced from ACCESS_CODES_PATH carry source='file' and are replaced to
+  match the file on every reload — so the phase-1 revocation story (delete the
+  line, let content sync deliver it) still works unchanged.
+- Rows minted by mint_code.py carry source='cli' and are never touched by file
+  sync. Revoke those with mint_code.py --revoke.
+
+Sessions are honest about surface semantics (see PLAN.md): a `web` session is
+a real conversation; an `mcp` session is a transport session (best-effort
+grouping); a `fetch` "session" is one code's traffic for one UTC day.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+import time
+from datetime import datetime, timezone
+
+DB_PATH = os.environ.get("AGENT_DB_PATH", "agent.db")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS codes (
+    code TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    expires TEXT,
+    url_auth INTEGER NOT NULL DEFAULT 0,
+    revoked INTEGER NOT NULL DEFAULT 0,
+    note TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL DEFAULT 'file',          -- 'file' | 'cli'
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    code TEXT NOT NULL,
+    surface TEXT NOT NULL,                        -- 'web' | 'mcp' | 'fetch'
+    client_name TEXT,
+    client_version TEXT,
+    ip TEXT,
+    user_agent TEXT,
+    started_at TEXT NOT NULL,
+    last_active_at TEXT NOT NULL,
+    ended_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    role TEXT NOT NULL,                           -- 'user' | 'assistant'
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd REAL NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
+
+-- Durable fixed-window counters (rate limits, budgets, failed attempts).
+-- key encodes the counter kind + subject; window is the fixed-window number.
+CREATE TABLE IF NOT EXISTS counters (
+    key TEXT PRIMARY KEY,
+    window INTEGER NOT NULL,
+    value REAL NOT NULL
+);
+"""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+class Store:
+    def __init__(self, path: str | None = None):
+        self.path = path or DB_PATH
+        self._lock = threading.Lock()
+        conn = self._conn()
+        conn.executescript(_SCHEMA)
+        conn.commit()
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.commit()
+        conn.close()
+
+    def _conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=30)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    # -- codes --------------------------------------------------------------
+
+    def sync_codes_from_file(self, parsed_codes: list) -> None:
+        """Replace all source='file' rows to match the file exactly. CLI-minted
+        rows are untouched, preserving both minting paths."""
+        with self._lock, self._conn() as conn:
+            conn.execute("DELETE FROM codes WHERE source = 'file'")
+            for c in parsed_codes:
+                conn.execute(
+                    "INSERT OR REPLACE INTO codes "
+                    "(code, label, expires, url_auth, revoked, note, source, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, 'file', ?)",
+                    (c.code, c.label, c.expires, int(c.url_auth),
+                     int(c.revoked), c.note, _now()))
+
+    def get_code(self, code: str) -> sqlite3.Row | None:
+        with self._conn() as conn:
+            return conn.execute("SELECT * FROM codes WHERE code = ?",
+                                (code,)).fetchone()
+
+    def upsert_cli_code(self, code: str, label: str, expires: str | None,
+                        url_auth: bool, note: str = "") -> None:
+        with self._lock, self._conn() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO codes "
+                "(code, label, expires, url_auth, revoked, note, source, created_at) "
+                "VALUES (?, ?, ?, ?, 0, ?, 'cli', ?)",
+                (code, label, expires, int(url_auth), note, _now()))
+
+    def revoke_cli_code(self, code: str) -> bool:
+        with self._lock, self._conn() as conn:
+            cur = conn.execute(
+                "UPDATE codes SET revoked = 1 WHERE code = ? AND source = 'cli'",
+                (code,))
+            return cur.rowcount > 0
+
+    def all_codes(self) -> list[sqlite3.Row]:
+        with self._conn() as conn:
+            return conn.execute("SELECT * FROM codes ORDER BY created_at").fetchall()
+
+    # -- sessions & messages ------------------------------------------------
+
+    def touch_session(self, session_id: str, code: str, surface: str,
+                      ip: str | None = None, user_agent: str | None = None,
+                      client_name: str | None = None,
+                      client_version: str | None = None) -> None:
+        """Create the session row if new; refresh last_active either way.
+        Client/UA fields only fill in when previously NULL (first writer wins)."""
+        now = _now()
+        with self._lock, self._conn() as conn:
+            conn.execute(
+                "INSERT INTO sessions (id, code, surface, client_name, "
+                "client_version, ip, user_agent, started_at, last_active_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET "
+                "last_active_at = excluded.last_active_at, "
+                "client_name = COALESCE(sessions.client_name, excluded.client_name), "
+                "client_version = COALESCE(sessions.client_version, excluded.client_version), "
+                "ip = COALESCE(sessions.ip, excluded.ip), "
+                "user_agent = COALESCE(sessions.user_agent, excluded.user_agent)",
+                (session_id, code, surface, client_name, client_version,
+                 ip, user_agent, now, now))
+
+    def end_session(self, session_id: str) -> None:
+        with self._lock, self._conn() as conn:
+            conn.execute("UPDATE sessions SET ended_at = ? WHERE id = ?",
+                         (_now(), session_id))
+
+    def record_exchange(self, session_id: str, question: str, answer: str,
+                        usage=None, cost_usd: float = 0.0) -> None:
+        get = (usage.get if isinstance(usage, dict)
+               else lambda k, d=0: getattr(usage, k, d) or 0) if usage else lambda k, d=0: 0
+        now = _now()
+        with self._lock, self._conn() as conn:
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, created_at) "
+                "VALUES (?, 'user', ?, ?)", (session_id, question, now))
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, created_at, "
+                "input_tokens, cache_read_tokens, cache_write_tokens, "
+                "output_tokens, cost_usd) VALUES (?, 'assistant', ?, ?, ?, ?, ?, ?, ?)",
+                (session_id, answer, now,
+                 get("input_tokens"), get("cache_read_input_tokens"),
+                 get("cache_creation_input_tokens"), get("output_tokens"),
+                 cost_usd))
+            conn.execute("UPDATE sessions SET last_active_at = ? WHERE id = ?",
+                         (now, session_id))
+
+    # -- durable fixed-window counters ---------------------------------------
+
+    def bump(self, key: str, amount: float, window_s: int,
+             now: float | None = None) -> float:
+        """Add to a fixed-window counter, resetting when the window rolls.
+        Returns the post-add value. amount=0 reads without counting."""
+        now = now if now is not None else time.time()
+        w = int(now // window_s)
+        with self._lock, self._conn() as conn:
+            row = conn.execute("SELECT window, value FROM counters WHERE key = ?",
+                               (key,)).fetchone()
+            value = (row["value"] if row and row["window"] == w else 0.0) + amount
+            conn.execute(
+                "INSERT OR REPLACE INTO counters (key, window, value) VALUES (?, ?, ?)",
+                (key, w, value))
+            return value
+
+    # -- reporting -----------------------------------------------------------
+
+    def summary(self) -> list[dict]:
+        """Per-code rollup for report.py / the admin endpoint."""
+        with self._conn() as conn:
+            rows = conn.execute("""
+                SELECT c.code, c.label, c.source, c.revoked,
+                       COUNT(DISTINCT s.id) AS sessions,
+                       COUNT(m.id) AS messages,
+                       COALESCE(SUM(m.cost_usd), 0) AS cost_usd,
+                       MAX(s.last_active_at) AS last_seen
+                FROM codes c
+                LEFT JOIN sessions s ON s.code = c.code
+                LEFT JOIN messages m ON m.session_id = s.id
+                GROUP BY c.code ORDER BY last_seen DESC NULLS LAST
+            """).fetchall()
+            return [dict(r) for r in rows]
+
+    def sessions_for_code(self, code: str) -> list[dict]:
+        with self._conn() as conn:
+            return [dict(r) for r in conn.execute(
+                "SELECT * FROM sessions WHERE code = ? ORDER BY started_at",
+                (code,)).fetchall()]
+
+    def transcript(self, session_id: str) -> list[dict]:
+        with self._conn() as conn:
+            return [dict(r) for r in conn.execute(
+                "SELECT role, content, created_at, cost_usd FROM messages "
+                "WHERE session_id = ? ORDER BY id", (session_id,)).fetchall()]
+
+
+class DurableLimiter:
+    """Store-backed drop-in for codes.Limiter — same API, restart-proof.
+    Closes the phase-1 'counters reset on restart' gap."""
+
+    def __init__(self, store: Store):
+        self.store = store
+
+    def allow_request(self, code: str) -> bool:
+        import codes as codes_mod
+        return (self.store.bump(f"req:{code}", 1, 3600)
+                <= codes_mod.RATE_LIMIT_PER_HOUR)
+
+    def record_spend(self, code: str, usd: float) -> None:
+        self.store.bump(f"spend:{code}", usd, 86400)
+        self.store.bump("spend:GLOBAL", usd, 86400)
+
+    def budget_ok(self, code: str) -> bool:
+        import codes as codes_mod
+        per = self.store.bump(f"spend:{code}", 0, 86400)
+        glob = self.store.bump("spend:GLOBAL", 0, 86400)
+        return (per < codes_mod.DAILY_BUDGET_USD_PER_CODE
+                and glob < codes_mod.DAILY_BUDGET_USD_GLOBAL)
+
+    def record_failed_attempt(self, ip: str) -> None:
+        self.store.bump(f"fail:{ip}", 1, 3600)
+        self.store.bump("fail:GLOBAL", 1, 3600)
+
+    def attempts_ok(self, ip: str) -> bool:
+        import codes as codes_mod
+        per = self.store.bump(f"fail:{ip}", 0, 3600)
+        glob = self.store.bump("fail:GLOBAL", 0, 3600)
+        return (per < codes_mod.FAILED_ATTEMPTS_PER_IP_HOUR
+                and glob < codes_mod.FAILED_ATTEMPTS_GLOBAL_HOUR)

--- a/candidate-agent/templates/chat.html
+++ b/candidate-agent/templates/chat.html
@@ -27,7 +27,8 @@
   <header>
     <strong>Candidate agent</strong>
     <p>AI agent answering on the candidate's behalf — session for {{LABEL}}.
-       Not the candidate. Answers come from their published documents.</p>
+       Not the candidate. Answers come from their published documents.
+       This conversation is recorded and reviewed by the candidate.</p>
   </header>
   <div id="log"></div>
   <form id="f">

--- a/candidate-agent/templates/entry.html
+++ b/candidate-agent/templates/entry.html
@@ -27,6 +27,6 @@
   </form>
   <p class="fine">You are talking to an AI agent, not the candidate.
      Answers are grounded in documents the candidate published for this
-     purpose.</p>
+     purpose. Conversations are recorded and reviewed by the candidate.</p>
 </body>
 </html>

--- a/candidate-agent/tests/test_app.py
+++ b/candidate-agent/tests/test_app.py
@@ -223,6 +223,31 @@ class SurfaceTest(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertIn("codes", r.json())
 
+    def test_admin_404_when_token_unset(self):
+        saved = os.environ.pop("ADMIN_TOKEN")
+        try:
+            self.assertEqual(
+                self.client.get("/admin/summary.json").status_code, 404)
+        finally:
+            os.environ["ADMIN_TOKEN"] = saved
+
+    def test_admin_guessing_hits_the_limiter(self):
+        import codes as codes_mod
+        for _ in range(codes_mod.FAILED_ATTEMPTS_PER_IP_HOUR):
+            self.client.get("/admin/summary.json",
+                            headers={"X-Admin-Token": "wrong"})
+        r = self.client.get("/admin/summary.json",
+                            headers={"X-Admin-Token": "test-admin-token"})
+        self.assertEqual(r.status_code, 429)     # even the right token: locked
+
+    def test_recorded_exchange_carries_real_cost(self):
+        # Locks the token -> usage_cost_usd -> DB chain end to end.
+        self._enter()
+        self.client.post("/chat", json={"message": "cost me"},
+                         headers={"X-Candidate-Agent": "1"})
+        row = {r["code"]: r for r in app_mod.db.summary()}["plain-code-1"]
+        self.assertGreater(row["cost_usd"], 0)
+
     def test_disclosure_present(self):
         self.assertIn("recorded", self.client.get("/").text)
         self.assertIn("recorded", self.client.get("/c/urlok-code-2").text)

--- a/candidate-agent/tests/test_app.py
+++ b/candidate-agent/tests/test_app.py
@@ -26,17 +26,46 @@ if _DEPS:
     _codes.close()
     os.environ["CORPUS_PATH"] = _root
     os.environ["ACCESS_CODES_PATH"] = _codes.name
+    os.environ["AGENT_DB_PATH"] = os.path.join(tempfile.mkdtemp(), "agent.db")
+    os.environ["ADMIN_TOKEN"] = "test-admin-token"
     os.environ.pop("REDACTION_DENYLIST_PATH", None)
 
     import app as app_mod
     from fastapi.testclient import TestClient
 
-    # Never hit the real API: stub the engine's entry points.
-    app_mod.engine.answer = lambda code, q, continuity_key=None: f"answer to: {q}"
-    def _stream(code, history, q):
-        yield "streamed "
-        yield "answer"
-    app_mod.engine.stream_answer = _stream
+    # Never hit the real API: stub the Anthropic CLIENT (not the engine), so
+    # the real engine paths — continuity, usage accounting, the phase-2
+    # recorder — all execute.
+    _USAGE = {"input_tokens": 10, "output_tokens": 5,
+              "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}
+
+    class _Block:
+        type = "text"
+
+    def _resp(text):
+        b = _Block(); b.text = text
+        r = _Block(); r.content = [b]; r.usage = dict(_USAGE)
+        return r
+
+    class _FakeStream:
+        def __enter__(self):
+            self.text_stream = iter(["streamed ", "answer"])
+            return self
+        def __exit__(self, *a):
+            return False
+        def get_final_message(self):
+            return _resp("streamed answer")
+
+    class _FakeMessages:
+        def create(self, **kw):
+            return _resp(f"answer to: {kw['messages'][-1]['content']}")
+        def stream(self, **kw):
+            return _FakeStream()
+
+    class _FakeClient:
+        messages = _FakeMessages()
+
+    app_mod.engine._client = _FakeClient()
 
 
 @unittest.skipUnless(_DEPS, "fastapi/fastmcp/httpx not installed")
@@ -53,8 +82,13 @@ class SurfaceTest(unittest.TestCase):
         cls.client.__exit__(None, None, None)
 
     def setUp(self):
-        app_mod.limiter = app_mod.codes_mod.Limiter()   # fresh counters
+        # Fresh durable counters per test: new DB file, re-attached everywhere.
+        os.environ["AGENT_DB_PATH"] = os.path.join(tempfile.mkdtemp(), "agent.db")
+        app_mod.db = app_mod.store_mod.Store(os.environ["AGENT_DB_PATH"])
+        app_mod.table.attach_store(app_mod.db)
+        app_mod.limiter = app_mod.store_mod.DurableLimiter(app_mod.db)
         app_mod.engine.limiter = app_mod.limiter
+        app_mod.engine.recorder = app_mod.db.record_exchange
 
     # -- basics -------------------------------------------------------------
 
@@ -157,6 +191,41 @@ class SurfaceTest(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         r2 = self._mcp_initialize(path="/mcp/urlok-code-2/")
         self.assertEqual(r2.status_code, 200)
+
+    # -- phase 2: recording, admin, disclosure ---------------------------
+
+    def test_web_chat_is_recorded(self):
+        self._enter()
+        self.client.post("/chat", json={"message": "record me"},
+                         headers={"X-Candidate-Agent": "1"})
+        summary = {r["code"]: r for r in app_mod.db.summary()}
+        row = summary["plain-code-1"]
+        self.assertEqual(row["sessions"], 1)
+        self.assertEqual(row["messages"], 2)
+        sess = app_mod.db.sessions_for_code("plain-code-1")[0]
+        self.assertEqual(sess["surface"], "web")
+        transcript = app_mod.db.transcript(sess["id"])
+        self.assertEqual(transcript[0]["content"], "record me")
+        self.assertEqual(transcript[1]["content"], "streamed answer")
+
+    def test_fetch_ask_is_recorded_as_day_session(self):
+        self.client.get("/c/urlok-code-2/ask", params={"q": "one"})
+        self.client.get("/c/urlok-code-2/ask", params={"q": "two"})
+        sessions = app_mod.db.sessions_for_code("urlok-code-2")
+        self.assertEqual(len(sessions), 1)          # same UTC day -> one session
+        self.assertEqual(sessions[0]["surface"], "fetch")
+        self.assertEqual(len(app_mod.db.transcript(sessions[0]["id"])), 4)
+
+    def test_admin_endpoint_gated(self):
+        self.assertEqual(self.client.get("/admin/summary.json").status_code, 401)
+        r = self.client.get("/admin/summary.json",
+                            headers={"X-Admin-Token": "test-admin-token"})
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("codes", r.json())
+
+    def test_disclosure_present(self):
+        self.assertIn("recorded", self.client.get("/").text)
+        self.assertIn("recorded", self.client.get("/c/urlok-code-2").text)
 
 
 if __name__ == "__main__":

--- a/candidate-agent/tests/test_store.py
+++ b/candidate-agent/tests/test_store.py
@@ -41,6 +41,35 @@ class CodeSyncTest(unittest.TestCase):
         self.assertIsNone(self.table.lookup("file-code-1"))
         self.assertEqual(self.table.lookup("other-code-2").label, "Other Co")
 
+    def test_removed_code_keeps_its_history_in_the_rollup(self):
+        # Revocation is every code's end state; its cost attribution must
+        # survive it (review finding on PR #74).
+        self.table.lookup("file-code-1")                 # sync into DB
+        self.db.touch_session("web:s", "file-code-1", "web")
+        self.db.record_exchange("web:s", "q", "a", None, cost_usd=0.05)
+        created = self.db.get_code("file-code-1")["created_at"]
+        self._rewrite("other-code-2 | Other Co\n")       # revoke by removal
+        self.assertIsNone(self.table.lookup("file-code-1"))
+        summary = {r["code"]: r for r in self.db.summary()}
+        self.assertIn("file-code-1", summary)            # tombstoned, not erased
+        self.assertEqual(summary["file-code-1"]["revoked"], 1)
+        self.assertAlmostEqual(summary["file-code-1"]["cost_usd"], 0.05)
+        # Re-adding the line un-revokes (file stays authoritative) and
+        # created_at survives the resync churn.
+        self._rewrite("file-code-1 | File Co | url_auth\n")
+        self.assertEqual(self.table.lookup("file-code-1").label, "File Co")
+        self.assertEqual(self.db.get_code("file-code-1")["created_at"], created)
+
+    def test_partial_usage_dict_records_with_zero_defaults(self):
+        # A dict missing token keys must not NULL a NOT NULL column and
+        # silently lose the exchange (review finding on PR #74).
+        db = _db(self)
+        db.touch_session("s", "c", "web")
+        db.record_exchange("s", "q", "a", {"output_tokens": 5}, cost_usd=0.01)
+        t = db.transcript("s")
+        self.assertEqual(len(t), 2)
+        self.assertEqual(t[1]["content"], "a")
+
     def test_cli_codes_survive_file_sync(self):
         self.db.upsert_cli_code("cli-code-9", "Minted Co", "2099-01-01", True)
         self._rewrite("file-code-1 | File Co\n")     # triggers resync

--- a/candidate-agent/tests/test_store.py
+++ b/candidate-agent/tests/test_store.py
@@ -1,0 +1,119 @@
+"""Phase-2 store tests: code sync semantics, durable counters, transcripts.
+Pure stdlib; synthetic data only."""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import codes  # noqa: E402
+import store  # noqa: E402
+
+
+def _db(self):
+    path = os.path.join(tempfile.mkdtemp(), "t.db")
+    return store.Store(path)
+
+
+class CodeSyncTest(unittest.TestCase):
+    def setUp(self):
+        self.db = _db(self)
+        self.codes_file = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False)
+        self.codes_file.write("file-code-1 | File Co | url_auth\n")
+        self.codes_file.close()
+        self.addCleanup(os.remove, self.codes_file.name)
+        self.table = codes.CodeTable(self.codes_file.name)
+        self.table.attach_store(self.db)
+
+    def _rewrite(self, text):
+        import time
+        with open(self.codes_file.name, "w") as f:
+            f.write(text)
+        os.utime(self.codes_file.name, (time.time() + 2, time.time() + 2))
+
+    def test_file_codes_sync_and_revoke_by_removal(self):
+        self.assertEqual(self.table.lookup("file-code-1").label, "File Co")
+        self.assertTrue(self.table.lookup("file-code-1").url_auth)
+        # Phase-1 revocation story must survive: delete the line -> gone.
+        self._rewrite("other-code-2 | Other Co\n")
+        self.assertIsNone(self.table.lookup("file-code-1"))
+        self.assertEqual(self.table.lookup("other-code-2").label, "Other Co")
+
+    def test_cli_codes_survive_file_sync(self):
+        self.db.upsert_cli_code("cli-code-9", "Minted Co", "2099-01-01", True)
+        self._rewrite("file-code-1 | File Co\n")     # triggers resync
+        self.assertEqual(self.table.lookup("cli-code-9").label, "Minted Co")
+        # ...and revoke via the CLI path, not the file.
+        self.assertTrue(self.db.revoke_cli_code("cli-code-9"))
+        self.assertIsNone(self.table.lookup("cli-code-9"))
+        # revoke_cli_code must not touch file-sourced rows
+        self.assertFalse(self.db.revoke_cli_code("file-code-1"))
+
+
+class DurableCounterTest(unittest.TestCase):
+    def test_counters_survive_restart(self):
+        path = os.path.join(tempfile.mkdtemp(), "t.db")
+        lim = store.DurableLimiter(store.Store(path))
+        lim.record_spend("c", 3.0)
+        # Simulate a process restart: fresh Store over the same file.
+        lim2 = store.DurableLimiter(store.Store(path))
+        self.assertAlmostEqual(lim2.store.bump("spend:c", 0, 86400), 3.0)
+
+    def test_window_rollover(self):
+        db = _db(self)
+        t0 = 1_000_000_000
+        self.assertEqual(db.bump("k", 5, 3600, now=t0), 5)
+        self.assertEqual(db.bump("k", 1, 3600, now=t0 + 10), 6)
+        self.assertEqual(db.bump("k", 1, 3600, now=t0 + 3600), 1)  # new window
+
+    def test_limiter_api_parity(self):
+        lim = store.DurableLimiter(_db(self))
+        allowed = [lim.allow_request("c") for _ in range(codes.RATE_LIMIT_PER_HOUR + 2)]
+        self.assertTrue(allowed[0])
+        self.assertFalse(allowed[-1])
+        self.assertTrue(lim.budget_ok("c"))
+        lim.record_spend("c", codes.DAILY_BUDGET_USD_PER_CODE + 1)
+        self.assertFalse(lim.budget_ok("c"))
+        for _ in range(codes.FAILED_ATTEMPTS_PER_IP_HOUR):
+            lim.record_failed_attempt("1.2.3.4")
+        self.assertFalse(lim.attempts_ok("1.2.3.4"))
+
+
+class RecordingTest(unittest.TestCase):
+    def test_sessions_messages_and_summary(self):
+        db = _db(self)
+        db.upsert_cli_code("c-1", "Acme", None, False)
+        db.touch_session("web:s1", "c-1", "web", ip="10.0.0.1", user_agent="UA")
+        db.record_exchange("web:s1", "q1", "a1",
+                           {"input_tokens": 10, "output_tokens": 5,
+                            "cache_read_input_tokens": 100,
+                            "cache_creation_input_tokens": 0},
+                           cost_usd=0.01)
+        db.touch_session("mcp:c-1:x", "c-1", "mcp",
+                         client_name="claude-code", client_version="2.0")
+        db.record_exchange("mcp:c-1:x", "q2", "a2", None, cost_usd=0.02)
+
+        summary = {r["code"]: r for r in db.summary()}
+        self.assertEqual(summary["c-1"]["sessions"], 2)
+        self.assertEqual(summary["c-1"]["messages"], 4)
+        self.assertAlmostEqual(summary["c-1"]["cost_usd"], 0.03)
+
+        transcript = db.transcript("web:s1")
+        self.assertEqual([m["role"] for m in transcript], ["user", "assistant"])
+        self.assertEqual(transcript[1]["content"], "a1")
+
+        sessions = db.sessions_for_code("c-1")
+        mcp = next(s for s in sessions if s["surface"] == "mcp")
+        self.assertEqual(mcp["client_name"], "claude-code")
+
+    def test_touch_first_writer_wins_on_identity(self):
+        db = _db(self)
+        db.touch_session("s", "c", "mcp", client_name="claude-code")
+        db.touch_session("s", "c", "mcp", client_name="someone-else")
+        self.assertEqual(db.sessions_for_code("c")[0]["client_name"], "claude-code")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements phase 2 of `candidate-agent/PLAN.md`: everything phase 1 kept in memory becomes durable and attributable.

## What's recorded
SQLite at `AGENT_DB_PATH` (WAL, 30s busy timeout, single-process — job-store's lessons). Sessions carry surface (`web` | `mcp` | `fetch`), IP, User-Agent, and for MCP the connecting client's name/version from the `initialize` handshake; messages carry full transcripts with token counts by class, so per-code cost is exact. Honest semantics per the plan: web sessions are conversations, MCP sessions are transport sessions (best-effort grouping), fetch groups one code's traffic per UTC day. Recording failures log loudly but never block an answer.

## Codes: file and DB coexist
File-sourced rows resync on reload — delete-the-line revocation keeps its phase-1 semantics — while `mint_code.py`-created rows are never touched by the sync (`--revoke` handles those). Rate limits, daily budgets, and the failed-attempt limiter move into durable fixed-window counters: restart-proof, closing phase 1's accepted gap.

## Operator surface
`report.py` (per-code rollup → sessions → transcript), `mint_code.py`, and `GET /admin/summary.json` behind `ADMIN_TOKEN` (404 when unset). Disclosure lines ("conversations are recorded and reviewed") on the entry page, chat header, fetch landing, and MCP descriptions. README is explicit that the DB is personal data about identifiable people.

## Packaging
`AGENT_DB_PATH=/data/agent.db` baked into the image with `/data` app-user-owned; helm PVC + `fsGroup`; compose volume.

## Verified
- 41 tests (was 30): store semantics (file-vs-CLI coexistence, counter window rollover and restart survival, transcripts), recording asserted through the real engine paths (Anthropic client stubbed one level deeper so the recorder executes), admin gate, disclosure presence.
- Live smoke against the real API on all three surfaces: recording confirmed in the DB for each, live code-minting accepted by the running server, durable spend read back after a process restart. Caught and fixed en route: FastMCP strips transport headers by default, so MCP session grouping silently fell back to per-code (`include_all=True`).
- Container-verified: DB written to `/data` as the non-root user, admin gate, code sync. Leak scan clean.

Deliberately unbuilt: retrieval rung 2 (FTS5) — the corpus hasn't outgrown full context, per the plan's climb condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)