### PR TITLE
candidate-agent: re-review follow-ups (admin auth hardening, persistence-off fix)

### DIFF
--- a/candidate-agent/app.py
+++ b/candidate-agent/app.py
@@ -286,11 +286,13 @@ def admin_summary(request: Request):
     ip = _client_ip(request)
     if not _admin_attempts_ok(ip):
         return JSONResponse({"error": "too many attempts"}, status_code=429)
-    # Compare BYTES: compare_digest on str raises TypeError on non-ASCII —
-    # which would 500 before the failed attempt is recorded (and permanently,
-    # for a non-ASCII ADMIN_TOKEN).
-    supplied = request.headers.get("x-admin-token", "").encode("utf-8")
-    if not secrets.compare_digest(supplied, token.encode("utf-8")):
+    # Compare BYTES, restoring each side's actual bytes: Starlette decodes
+    # headers as latin-1 (so latin-1 re-encode round-trips the wire bytes),
+    # and env values may carry surrogate-escaped invalid UTF-8 (os.fsencode
+    # round-trips those). A str compare_digest would TypeError on non-ASCII;
+    # a utf-8 re-encode would mismatch every non-ASCII token.
+    supplied = request.headers.get("x-admin-token", "").encode("latin-1")
+    if not secrets.compare_digest(supplied, os.fsencode(token)):
         db.bump(f"adminfail:{ip}", 1, 3600)
         db.bump("adminfail:GLOBAL", 1, 3600)
         return JSONResponse({"error": "unauthorized"}, status_code=401)

--- a/candidate-agent/app.py
+++ b/candidate-agent/app.py
@@ -268,20 +268,31 @@ def healthz():
     return {"ok": True}
 
 
+def _admin_attempts_ok(ip: str) -> bool:
+    # Deliberately NOT the shared fail: counters: admin-token guessing is
+    # unauthenticated traffic and must not be able to trip the global breaker
+    # that locks out legitimate employers on every other surface.
+    import codes as _c
+    return (db.bump(f"adminfail:{ip}", 0, 3600) < _c.FAILED_ATTEMPTS_PER_IP_HOUR
+            and db.bump("adminfail:GLOBAL", 0, 3600) < _c.FAILED_ATTEMPTS_GLOBAL_HOUR)
+
+
 @app.get("/admin/summary.json")
 def admin_summary(request: Request):
     token = os.environ.get("ADMIN_TOKEN")
     if not token:
         return JSONResponse({"error": "admin disabled (ADMIN_TOKEN unset)"},
                             status_code=404)
-    # Same failed-attempt limiting as every other credential path — this is
-    # the endpoint that returns the personal-data rollup — plus a
-    # constant-time compare.
     ip = _client_ip(request)
-    if not limiter.attempts_ok(ip):
+    if not _admin_attempts_ok(ip):
         return JSONResponse({"error": "too many attempts"}, status_code=429)
-    if not secrets.compare_digest(request.headers.get("x-admin-token", ""), token):
-        limiter.record_failed_attempt(ip)
+    # Compare BYTES: compare_digest on str raises TypeError on non-ASCII —
+    # which would 500 before the failed attempt is recorded (and permanently,
+    # for a non-ASCII ADMIN_TOKEN).
+    supplied = request.headers.get("x-admin-token", "").encode("utf-8")
+    if not secrets.compare_digest(supplied, token.encode("utf-8")):
+        db.bump(f"adminfail:{ip}", 1, 3600)
+        db.bump("adminfail:GLOBAL", 1, 3600)
         return JSONResponse({"error": "unauthorized"}, status_code=401)
     return JSONResponse({"codes": db.summary()})
 

--- a/candidate-agent/helm/templates/deployment.yaml
+++ b/candidate-agent/helm/templates/deployment.yaml
@@ -54,10 +54,12 @@ spec:
               value: {{ $v | quote }}
             {{- end }}
             {{- end }}
-            {{- if not .Values.persistence.enabled }}
+            {{- if and (not .Values.persistence.enabled) (not (hasKey .Values.env "AGENT_DB_PATH")) }}
             # No /data volume without persistence; fall back to the tmp
             # emptyDir so the image's baked AGENT_DB_PATH can't crashloop a
             # read-only rootfs. Recording/limits reset on restart in this mode.
+            # An explicit env.AGENT_DB_PATH (bring-your-own volume via
+            # extraVolumes) wins — the guard keeps this from shadowing it.
             - name: AGENT_DB_PATH
               value: /tmp/agent.db
             {{- end }}

--- a/candidate-agent/helm/templates/deployment.yaml
+++ b/candidate-agent/helm/templates/deployment.yaml
@@ -54,6 +54,13 @@ spec:
               value: {{ $v | quote }}
             {{- end }}
             {{- end }}
+            {{- if not .Values.persistence.enabled }}
+            # No /data volume without persistence; fall back to the tmp
+            # emptyDir so the image's baked AGENT_DB_PATH can't crashloop a
+            # read-only rootfs. Recording/limits reset on restart in this mode.
+            - name: AGENT_DB_PATH
+              value: /tmp/agent.db
+            {{- end }}
             {{- if .Values.adminTokenSecret.name }}
             - name: ADMIN_TOKEN
               valueFrom:

--- a/candidate-agent/helm/templates/deployment.yaml
+++ b/candidate-agent/helm/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               value: {{ $v | quote }}
             {{- end }}
             {{- end }}
-            {{- if and (not .Values.persistence.enabled) (not (hasKey .Values.env "AGENT_DB_PATH")) }}
+            {{- if and (not .Values.persistence.enabled) (not (get (default dict .Values.env) "AGENT_DB_PATH")) }}
             # No /data volume without persistence; fall back to the tmp
             # emptyDir so the image's baked AGENT_DB_PATH can't crashloop a
             # read-only rootfs. Recording/limits reset on restart in this mode.

--- a/candidate-agent/helm/values.yaml
+++ b/candidate-agent/helm/values.yaml
@@ -36,6 +36,10 @@ ingress:
   annotations: {}
 
 # Phase-2 session/transcript DB (AGENT_DB_PATH=/data/agent.db in the image).
+# enabled=false is EPHEMERAL mode: the DB moves to the pod's tmp emptyDir, so
+# transcripts, session history, rate limits and daily budget counters all
+# reset on every restart — the durable-limits guarantee only holds with
+# persistence on (or an explicit env.AGENT_DB_PATH onto your own volume).
 persistence:
   enabled: true
   size: 1Gi

--- a/candidate-agent/store.py
+++ b/candidate-agent/store.py
@@ -6,9 +6,10 @@ at a mounted volume). WAL + generous busy timeout, single-process serving
 the hard way there.
 
 Code-table semantics (the phase-1 file stays first-class):
-- Rows synced from ACCESS_CODES_PATH carry source='file' and are replaced to
-  match the file on every reload — so the phase-1 revocation story (delete the
-  line, let content sync deliver it) still works unchanged.
+- Rows synced from ACCESS_CODES_PATH carry source='file'. On reload, rows
+  absent from the file are TOMBSTONED (revoked), never deleted — the phase-1
+  revocation story (delete the line) still works, while the code's sessions
+  and cost stay visible in every rollup. Re-adding a line un-revokes.
 - Rows minted by mint_code.py carry source='cli' and are never touched by file
   sync. Revoke those with mint_code.py --revoke.
 
@@ -96,7 +97,8 @@ class Store:
         import time as _time
         hour_w, day_w = int(_time.time() // 3600), int(_time.time() // 86400)
         conn.execute("DELETE FROM counters WHERE (key LIKE 'req:%' OR "
-                     "key LIKE 'fail:%') AND window < ?", (hour_w,))
+                     "key LIKE 'fail:%' OR key LIKE 'adminfail:%') "
+                     "AND window < ?", (hour_w,))
         conn.execute("DELETE FROM counters WHERE key LIKE 'spend:%' "
                      "AND window < ?", (day_w,))
         conn.commit()

--- a/candidate-agent/tests/test_app.py
+++ b/candidate-agent/tests/test_app.py
@@ -252,6 +252,19 @@ class SurfaceTest(unittest.TestCase):
                             headers={b"X-Admin-Token": "wröng".encode("latin-1")})
         self.assertEqual(r.status_code, 401)
 
+    def test_admin_non_ascii_token_authenticates(self):
+        # A non-ASCII ADMIN_TOKEN must WORK, not 401 forever (PR #75 review):
+        # utf-8 wire bytes -> latin-1 decode -> latin-1 re-encode round-trips.
+        saved = os.environ["ADMIN_TOKEN"]
+        os.environ["ADMIN_TOKEN"] = "töken"
+        try:
+            r = self.client.get(
+                "/admin/summary.json",
+                headers={b"X-Admin-Token": "töken".encode("utf-8")})
+            self.assertEqual(r.status_code, 200)
+        finally:
+            os.environ["ADMIN_TOKEN"] = saved
+
     def test_recorded_exchange_carries_real_cost(self):
         # Locks the token -> usage_cost_usd -> DB chain end to end.
         self._enter()

--- a/candidate-agent/tests/test_app.py
+++ b/candidate-agent/tests/test_app.py
@@ -258,6 +258,9 @@ class SurfaceTest(unittest.TestCase):
         # the admin rollup — that's the surface you reach for DURING a storm.
         import codes as codes_mod
         app_mod.db.bump("fail:GLOBAL", codes_mod.FAILED_ATTEMPTS_GLOBAL_HOUR, 3600)
+        # Precondition: the lockout is genuinely in effect (guards against the
+        # key/ceiling drifting and this test passing vacuously).
+        self.assertEqual(self._enter().status_code, 403)
         r = self.client.get("/admin/summary.json",
                             headers={"X-Admin-Token": "test-admin-token"})
         self.assertEqual(r.status_code, 200)

--- a/candidate-agent/tests/test_app.py
+++ b/candidate-agent/tests/test_app.py
@@ -252,6 +252,16 @@ class SurfaceTest(unittest.TestCase):
                             headers={b"X-Admin-Token": "wröng".encode("latin-1")})
         self.assertEqual(r.status_code, 401)
 
+    def test_code_lockout_does_not_block_admin(self):
+        # The reverse of the decoupling test, and the operationally important
+        # direction: a tripped fail:GLOBAL (code-guessing storm) must not 429
+        # the admin rollup — that's the surface you reach for DURING a storm.
+        import codes as codes_mod
+        app_mod.db.bump("fail:GLOBAL", codes_mod.FAILED_ATTEMPTS_GLOBAL_HOUR, 3600)
+        r = self.client.get("/admin/summary.json",
+                            headers={"X-Admin-Token": "test-admin-token"})
+        self.assertEqual(r.status_code, 200)
+
     def test_admin_non_ascii_token_authenticates(self):
         # A non-ASCII ADMIN_TOKEN must WORK, not 401 forever (PR #75 review):
         # utf-8 wire bytes -> latin-1 decode -> latin-1 re-encode round-trips.

--- a/candidate-agent/tests/test_app.py
+++ b/candidate-agent/tests/test_app.py
@@ -239,6 +239,18 @@ class SurfaceTest(unittest.TestCase):
         r = self.client.get("/admin/summary.json",
                             headers={"X-Admin-Token": "test-admin-token"})
         self.assertEqual(r.status_code, 429)     # even the right token: locked
+        # Decoupled counters: admin guessing must NOT lock out employers on
+        # the other surfaces (re-review finding on PR #74).
+        self.assertEqual(self._enter().status_code, 200)
+
+    def test_admin_non_ascii_header_is_401_not_500(self):
+        # compare_digest on str raises TypeError on non-ASCII (Starlette
+        # decodes headers as latin-1, so obs-text reaches the handler);
+        # comparing bytes must yield a clean 401. httpx refuses non-ASCII
+        # str headers, so send raw bytes.
+        r = self.client.get("/admin/summary.json",
+                            headers={b"X-Admin-Token": "wröng".encode("latin-1")})
+        self.assertEqual(r.status_code, 401)
 
     def test_recorded_exchange_carries_real_cost(self):
         # Locks the token -> usage_cost_usd -> DB chain end to end.


### PR DESCRIPTION
Applies the three findings from the automated re-review on #74, which posted after the merge watcher had already fired (the review check passes whenever the run completes — it's advisory, not a gate).

1. **Admin token compared as bytes** — `secrets.compare_digest` on `str` raises `TypeError` on non-ASCII; Starlette decodes headers as latin-1, so an attacker could 500 the handler *before* the failed attempt was recorded, and a non-ASCII `ADMIN_TOKEN` would 500 permanently. Regression test sends a raw latin-1 header and asserts 401.
2. **Admin guessing decoupled from the shared breaker** — dedicated `adminfail:` counters (same thresholds, same startup sweep) so unauthenticated admin-token guessing can no longer trip `fail:GLOBAL` and lock out legitimate employers on every surface. Test pins that a locked admin IP can still enter a code on `/session`.
3. **`persistence.enabled=false` no longer crashloops** — the chart overrides the image's baked `AGENT_DB_PATH` to the tmp emptyDir when persistence is off (recording/limits become ephemeral in that mode, stated in place). Verified in the rendered template.
4. `store.py`'s module docstring caught up with the tombstone semantics.

47 tests green; leak scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)