### PR TITLE
job-board/overnight: discovery agent — crawl job indexers, prescreen on a local LLM

### DIFF
--- a/.github/workflows/test-overnight.yaml
+++ b/.github/workflows/test-overnight.yaml
@@ -1,0 +1,24 @@
+name: Test overnight agent
+
+# Stdlib-only test suite for job-board/overnight — no pip install needed.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'job-board/overnight/**'
+      - '.github/workflows/test-overnight.yaml'
+  pull_request:
+    paths:
+      - 'job-board/overnight/**'
+      - '.github/workflows/test-overnight.yaml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - run: python -m unittest discover -s tests
+        working-directory: job-board/overnight

--- a/job-board/overnight/README.md
+++ b/job-board/overnight/README.md
@@ -1,0 +1,158 @@
+# Overnight discovery agent
+
+Crawls public job sources for senior infrastructure roles at companies the watch
+list has never heard of, prescreens them for free on a local LLM, and submits
+only the survivors for paid scoring.
+
+**This is not a poller.** `job-store/poller.py` already covers the watch list on
+a CronJob. This widens the funnel to companies outside it. Roles from companies
+already being watched are skipped on sight.
+
+```
+sources (HN, WWR) -> dedupe vs job-store seen-set -> local prescreen (free)
+   -> POST survivors to /jobs/score (paid, capped) -> CSV + morning report
+```
+
+## What you need
+
+1. **A running job-store** (see `../job-store/`) reachable over HTTP — the
+   agent reads its seen-set and resume, and submits survivors to it.
+2. **A local LLM endpoint speaking the OpenAI chat API** with support for
+   grammar-constrained JSON (`json_schema` response format). llama.cpp's
+   `llama-server` behind [llama-swap](https://github.com/mostlygeek/llama-swap)
+   is the tested path; anything API-compatible works. You want two model
+   aliases:
+   - a **triage model**: small, fast, ideally GPU-resident, served with
+     several parallel slots (this stage sees every posting);
+   - a **gate/fit model**: your strongest local instruction-follower (this
+     stage sees only triage survivors, so slow is fine overnight).
+   If your models are "thinking" models, the client already disables that
+   per-request — see the gotchas below.
+3. **A gates file** — your private hard requirements (below).
+4. Python 3 stdlib. There is nothing to `pip install`.
+
+## Run it
+
+```bash
+export JOB_STORE=https://<your-job-store>          # or --backend
+export LLAMA_SWAP=http://<your-llm-host>:8080      # or --llm; default localhost:8080
+export DISCOVERY_USER_AGENT="overnight-discovery/0.1 (job search agent; you@example.com)"
+
+python3 discover.py --gates ~/private/gates.txt --out ~/reports            # dry run
+python3 discover.py --gates ~/private/gates.txt --out ~/reports --submit   # spends money
+```
+
+Set `DISCOVERY_USER_AGENT` to something that identifies *you* with a contact
+path — an honest UA is part of being a polite bot; the default names only the
+toolkit.
+
+Dry run is the default and screens everything without POSTing, so you can read a
+morning report and tune the funnel before letting it spend.
+
+| flag | default | |
+|---|---|---|
+| `--gates` | `$GATES_PATH` | **required** — your hard requirements, see below |
+| `--out` | — | report directory; keep it on durable storage |
+| `--submit` | off | actually pay for authoritative scoring |
+| `--max-submit` | 25 | hard cap on paid calls per night |
+| `--sources` | `hn,wwr` | which collectors to run |
+| `--max-per-source` | 400 | cap postings pulled per source |
+| `--triage-workers` | 8 | match your triage model's parallel slots (`-np`) |
+| `--gate-workers` | 1 | match your gate model's parallel slots — more just queues |
+| `--triage-model` | `$TRIAGE_MODEL` / `scorer` | model alias for the triage stage |
+| `--gate-model` | `$GATE_MODEL` / `coder` | model alias for the gates+fit stage |
+| `--backend` | `$JOB_STORE` | job-store base URL (**required**) |
+| `--llm` | `$LLAMA_SWAP` | OpenAI-compatible LLM base URL |
+
+## The gates file
+
+job-store keeps preferences server-side (`PREFERENCES_PATH`) and exposes no
+endpoint to read them, so the local prescreen needs its own copy. Plain text,
+one requirement per line — level band, location/timezone, excluded role
+families, comp floor. It is personal data: keep it on a LAN machine and **never
+commit it**. See `gates.example.txt`.
+
+## Sources
+
+| source | mechanism | why |
+|---|---|---|
+| `hn` | [HN Algolia API](https://hn.algolia.com/api) over the monthly *Ask HN: Who is hiring?* thread | ~440 postings/month, heavily remote senior infra, companies that never touch job boards. Official API, no scraping |
+| `wwr` | WeWorkRemotely category RSS | Official feeds. `robots.txt` allows `/` except admin/account paths (checked 2026-08-02) |
+
+**RemoteOK is deliberately not implemented.** Its `robots.txt` disallows
+`/*?action=get_jobs` — the JSON jobs API — for all user agents, and individually
+blocks every major AI crawler (ClaudeBot, GPTBot, CCBot, Google-Extended, …).
+The site has said no.
+
+Only **top-level** HN comments are treated as postings; replies are discussion.
+Without that filter roughly half of what you collect is people arguing about
+compensation.
+
+## Things that will bite you
+
+**`chat_template_kwargs={"enable_thinking": false}` is mandatory.** Without it
+the Qwen models emit a `reasoning_content` block, spend the entire token budget
+on it, and return `content: ""` with `finish_reason: "length"`. It fails as an
+empty string rather than an error, so it reads like a bad prompt.
+
+**Schema descriptions are not instructions.** With the rubric only in the JSON
+schema's `description` fields, `fit_sketch` came back `0` on every posting and
+`pace_signals` was always empty. Moving explicit range anchors into the system
+prompt fixed it — same posting, three pinned seeds: `0,0,0` → `92,92,92`. If a
+numeric field looks dead, put the rubric in the prompt.
+
+**Field order in the schema is load-bearing.** Grammar-constrained decoding emits
+properties in schema order, so `evidence`/`gaps` must come before `score` to
+force reasoning ahead of the number. Keep score fields last.
+
+**The gate model is slow on full JDs** — expect single-digit postings per
+minute cold on a CPU-offloaded MoE. Fine overnight, but it means the free
+rules stage has to do the heavy filtering. Order is deliberate: regex →
+small GPU-resident model → big model.
+
+**The prescreen fails open.** If the model errors, the posting is kept and the
+error recorded. A model problem must never silently shrink the funnel.
+
+## Guardrails
+
+- Nothing is POSTed without `--submit`; `--max-submit` caps the spend.
+- `force` is never sent, so re-POSTing a known URL returns the cached analysis
+  free of charge.
+- The seen-set is fetched before anything else and every known dedupe key skipped.
+- Sources use official APIs/feeds, send an honest User-Agent, and are rate-limited
+  per host. `fetch.PoliteFetcher` also drops a host for the night after repeated
+  403/429 rather than backing off into a block.
+- Companies are **never** auto-added to the watch list. The report lists the ones
+  that produced keeps; adding them stays a human decision.
+- Keep reports on durable storage — if your LLM host's disks are scratch
+  (a common shape for homelab inference boxes), sync the report directory
+  somewhere that survives.
+
+## Layout
+
+| file | |
+|---|---|
+| `discover.py` | orchestrator + CLI |
+| `gates.example.txt` | template for the private `--gates` file |
+| `sources/` | `hn.py`, `wwr.py` — pluggable collectors returning a common shape |
+| `prescreen.py` | rules → triage → gates+fit funnel |
+| `llm.py` | llama-swap client, grammar-constrained JSON, schemas |
+| `fetch.py` | rate limiting + circuit breaker; reuses `job-store/adapters` |
+| `report.py` | CSV + morning markdown, including the rejection log |
+
+## Scheduling
+
+Any scheduler works; the agent is a single nightly invocation. A crontab
+example (systemd-timer equivalents apply):
+
+```cron
+30 2 * * *  JOB_STORE=... LLAMA_SWAP=... GATES_PATH=... /usr/bin/python3 /path/to/discover.py --out /srv/reports --submit >> /srv/reports/run.log 2>&1
+```
+
+Start with a few dry-run nights and read the rejection log before adding
+`--submit`. If your LLM host swaps models on demand with an idle TTL, mind
+that long gaps between stages can pay a model reload.
+
+The rejection log is the point of the CSV: every drop records which stage killed
+it and why, so "what did it throw away, and was it right?" is answerable in the
+morning. That question is what makes the thresholds tunable instead of folklore.

--- a/job-board/overnight/README.md
+++ b/job-board/overnight/README.md
@@ -95,7 +95,8 @@ a best-effort pick from the comment's links — occasionally a company homepage
 rather than the posting. That's an accepted trade for HN's unique signal, but
 it means an HN submission can put a homepage-URL row with a blurb-quality
 description on the board; the morning report is where you catch those.
-Comments under the backend's minimum description length upsert unscored.
+Comments under the backend's 100-char scoring minimum are dropped at
+collection, so they can't eat a submission slot.
 
 ## Things that will bite you
 
@@ -132,9 +133,11 @@ error recorded. A model problem must never silently shrink the funnel.
 - `force` is never sent, so re-POSTing a known URL returns the cached analysis
   free of charge.
 - The seen-set is fetched before anything else and every known dedupe key skipped.
-- Sources use official APIs/feeds, send an honest User-Agent, and are rate-limited
-  per host. `fetch.PoliteFetcher` also drops a host for the night after repeated
-  403/429 rather than backing off into a block.
+- Sources use official APIs/feeds, send an honest User-Agent, and are
+  rate-limited per host — and every source fetch shares a per-host circuit
+  breaker (`sources.polite_get`) that drops a host for the night after
+  repeated 403/429 rather than backing off into a block.
+  `fetch.PoliteFetcher` applies the same policy to adapter-based fetching.
 - Companies are **never** auto-added to the watch list. The report lists the ones
   that produced keeps; adding them stays a human decision.
 - Keep reports on durable storage — if your LLM host's disks are scratch

--- a/job-board/overnight/README.md
+++ b/job-board/overnight/README.md
@@ -135,8 +135,8 @@ error recorded. A model problem must never silently shrink the funnel.
 - The seen-set is fetched before anything else and every known dedupe key skipped.
 - Sources use official APIs/feeds, send an honest User-Agent, and are
   rate-limited per host — and every source fetch shares a per-host circuit
-  breaker (`sources.polite_get`) that drops a host for the night after
-  repeated 403/429 rather than backing off into a block.
+  breaker (`sources.polite_get`) that drops a host for the night on a 403/429
+  (`SOURCE_BLOCK_AFTER`, default 1) rather than retrying into a block.
   `fetch.PoliteFetcher` applies the same policy to adapter-based fetching.
 - Companies are **never** auto-added to the watch list. The report lists the ones
   that produced keeps; adding them stays a human decision.

--- a/job-board/overnight/README.md
+++ b/job-board/overnight/README.md
@@ -63,6 +63,8 @@ morning report and tune the funnel before letting it spend.
 | `--gate-model` | `$GATE_MODEL` / `coder` | model alias for the gates+fit stage |
 | `--title-drops-extra` | `$TITLE_DROPS_EXTRA` | comma-separated title words to drop on sight. The built-in list drops only clearly-entry-level titles; **your** band/family exclusions (staff, manager, frontend, …) go here or in the gates file — they're personal config, not toolkit code |
 | `--model-dead-after` | `$MODEL_DEAD_AFTER` / 2 | give up on a local model after this many timeouts in a run (bounds wall-clock if the LLM host hangs) |
+| — | `$SOURCE_MIN_DELAY_S` / 2.0 | minimum seconds between requests to one host (source politeness) |
+| — | `$SOURCE_BLOCK_AFTER` / 1 | 403/429s from a host before dropping it for the night |
 | `--backend` | `$JOB_STORE` | job-store base URL (**required**) |
 | `--llm` | `$LLAMA_SWAP` | OpenAI-compatible LLM base URL |
 

--- a/job-board/overnight/README.md
+++ b/job-board/overnight/README.md
@@ -62,6 +62,7 @@ morning report and tune the funnel before letting it spend.
 | `--triage-model` | `$TRIAGE_MODEL` / `scorer` | model alias for the triage stage |
 | `--gate-model` | `$GATE_MODEL` / `coder` | model alias for the gates+fit stage |
 | `--title-drops-extra` | `$TITLE_DROPS_EXTRA` | comma-separated title words to drop on sight. The built-in list drops only clearly-entry-level titles; **your** band/family exclusions (staff, manager, frontend, …) go here or in the gates file — they're personal config, not toolkit code |
+| `--model-dead-after` | `$MODEL_DEAD_AFTER` / 2 | give up on a local model after this many timeouts in a run (bounds wall-clock if the LLM host hangs) |
 | `--backend` | `$JOB_STORE` | job-store base URL (**required**) |
 | `--llm` | `$LLAMA_SWAP` | OpenAI-compatible LLM base URL |
 
@@ -130,6 +131,12 @@ error recorded. A model problem must never silently shrink the funnel.
   errored (`stage=error`) appears in the report for human review but is
   excluded from submission — a gate-model outage cannot convert the submit
   cap into unscreened paid calls.
+- **The wall clock is bounded, not just the spend**: `--max-submit` caps paid
+  calls, and `--model-dead-after` (default 2) makes the agent give up on a
+  local model that keeps timing out — a hung LLM host ends the night in
+  minutes with a report full of screen-failures, instead of grinding one
+  cold-start timeout per posting into the next day's run. Failed screens are
+  reported, never submitted.
 - `force` is never sent, so re-POSTing a known URL returns the cached analysis
   free of charge.
 - The seen-set is fetched before anything else and every known dedupe key skipped.

--- a/job-board/overnight/README.md
+++ b/job-board/overnight/README.md
@@ -146,7 +146,6 @@ error recorded. A model problem must never silently shrink the funnel.
   rate-limited per host — and every source fetch shares a per-host circuit
   breaker (`sources.polite_get`) that drops a host for the night on a 403/429
   (`SOURCE_BLOCK_AFTER`, default 1) rather than retrying into a block.
-  `fetch.PoliteFetcher` applies the same policy to adapter-based fetching.
 - Companies are **never** auto-added to the watch list. The report lists the ones
   that produced keeps; adding them stays a human decision.
 - Keep reports on durable storage — if your LLM host's disks are scratch
@@ -162,7 +161,7 @@ error recorded. A model problem must never silently shrink the funnel.
 | `sources/` | `hn.py`, `wwr.py` — pluggable collectors returning a common shape |
 | `prescreen.py` | rules → triage → gates+fit funnel |
 | `llm.py` | llama-swap client, grammar-constrained JSON, schemas |
-| `fetch.py` | rate limiting + circuit breaker; reuses `job-store/adapters` |
+| `fetch.py` | **scaffolding, not yet wired** — a `PoliteFetcher` over the reused `job-store/adapters` for a future adapter-based source. Today's sources (hn, wwr) use raw APIs/RSS via `sources.polite_get`, so nothing imports this yet |
 | `report.py` | CSV + morning markdown, including the rejection log |
 
 ## Scheduling

--- a/job-board/overnight/README.md
+++ b/job-board/overnight/README.md
@@ -61,6 +61,7 @@ morning report and tune the funnel before letting it spend.
 | `--gate-workers` | 1 | match your gate model's parallel slots — more just queues |
 | `--triage-model` | `$TRIAGE_MODEL` / `scorer` | model alias for the triage stage |
 | `--gate-model` | `$GATE_MODEL` / `coder` | model alias for the gates+fit stage |
+| `--title-drops-extra` | `$TITLE_DROPS_EXTRA` | comma-separated title words to drop on sight. The built-in list drops only clearly-entry-level titles; **your** band/family exclusions (staff, manager, frontend, …) go here or in the gates file — they're personal config, not toolkit code |
 | `--backend` | `$JOB_STORE` | job-store base URL (**required**) |
 | `--llm` | `$LLAMA_SWAP` | OpenAI-compatible LLM base URL |
 
@@ -87,6 +88,14 @@ The site has said no.
 Only **top-level** HN comments are treated as postings; replies are discussion.
 Without that filter roughly half of what you collect is people arguing about
 compensation.
+
+**HN postings are lower-fidelity than board postings, by nature.** The
+"description" is the comment text (sometimes a blurb, not a JD) and the URL is
+a best-effort pick from the comment's links — occasionally a company homepage
+rather than the posting. That's an accepted trade for HN's unique signal, but
+it means an HN submission can put a homepage-URL row with a blurb-quality
+description on the board; the morning report is where you catch those.
+Comments under the backend's minimum description length upsert unscored.
 
 ## Things that will bite you
 
@@ -116,6 +125,10 @@ error recorded. A model problem must never silently shrink the funnel.
 ## Guardrails
 
 - Nothing is POSTed without `--submit`; `--max-submit` caps the spend.
+- **Fail-open never reaches the paid stage**: a posting kept because a model
+  errored (`stage=error`) appears in the report for human review but is
+  excluded from submission — a gate-model outage cannot convert the submit
+  cap into unscreened paid calls.
 - `force` is never sent, so re-POSTing a known URL returns the cached analysis
   free of charge.
 - The seen-set is fetched before anything else and every known dedupe key skipped.

--- a/job-board/overnight/discover.py
+++ b/job-board/overnight/discover.py
@@ -35,7 +35,11 @@ import urllib.request
 from collections import Counter
 from pathlib import Path
 
-from fetch import compute_dedupe_key
+# compute_dedupe_key lives in job-store's urls.py; import it directly rather
+# than via fetch, which would drag all six ATS adapter modules into the graph
+# just for this one function. fetch.py does the sys.path insert we rely on.
+import fetch  # noqa: F401  (performs the job-store sys.path insert)
+from urls import compute_dedupe_key
 from llm import LlamaSwap
 from prescreen import Decision, Prescreener
 from report import write_reports
@@ -99,6 +103,11 @@ def main(argv: list[str] | None = None) -> int:
                     help="model alias for the cheap triage stage (env TRIAGE_MODEL)")
     ap.add_argument("--gate-model", default=os.environ.get("GATE_MODEL", "coder"),
                     help="model alias for the gates+fit stage (env GATE_MODEL)")
+    ap.add_argument("--model-dead-after", type=int,
+                    default=int(os.environ.get("MODEL_DEAD_AFTER", "2")),
+                    help="give up on a local model after this many timeouts in "
+                         "a run (env MODEL_DEAD_AFTER) — bounds wall-clock when "
+                         "the LLM host hangs")
     ap.add_argument("--title-drops-extra",
                     default=os.environ.get("TITLE_DROPS_EXTRA"),
                     help="comma-separated words/phrases to drop on sight in "
@@ -123,7 +132,15 @@ def main(argv: list[str] | None = None) -> int:
     if not args.backend:
         ap.error("--backend (or env JOB_STORE) is required — your job-store URL")
     print(f"[*] backend {args.backend}")
-    seen_resp = http_json(f"{args.backend}/jobs/urls")
+    try:
+        seen_resp = http_json(f"{args.backend}/jobs/urls")
+    except Exception as err:                            # noqa: BLE001
+        # Fail closed on the seen-set: without it every survivor re-scores.
+        # A one-line message beats a raw traceback (matches the /resume 404).
+        print(f"[!] cannot reach job-store at {args.backend} "
+              f"({type(err).__name__}: {err}). Is JOB_STORE correct and the "
+              f"backend up?", file=sys.stderr)
+        return 2
     seen = seen_keys(seen_resp)
     print(f"[*] seen-set: {len(seen)} dedupe keys")
     if not seen:
@@ -206,7 +223,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     # --- prescreen (free) -------------------------------------------------
-    llm = LlamaSwap(args.llm)
+    llm = LlamaSwap(args.llm, dead_after=args.model_dead_after)
     screener = Prescreener(llm, gates_text=gates_text, resume_text=resume_text,
                            triage_model=args.triage_model,
                            screen_model=args.gate_model,
@@ -223,6 +240,7 @@ def main(argv: list[str] | None = None) -> int:
             triage_workers=args.triage_workers,
             gate_workers=args.gate_workers,
             progress=lambda m: print(f"[*] {m}"),
+            problems=errors,
         )
     except BaseException as err:                     # includes KeyboardInterrupt
         errors.append(f"prescreen aborted: {type(err).__name__}: {err}")

--- a/job-board/overnight/discover.py
+++ b/job-board/overnight/discover.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Overnight discovery: crawl for good roles at companies we don't watch yet.
+
+    sources (HN, WWR) -> dedupe vs job-store's seen-set -> local prescreen (free)
+      -> POST survivors for authoritative scoring (paid) -> CSV + morning report
+
+This is deliberately NOT a poller. The poller already covers the watch list on a
+CronJob; running it again here would spend money to learn nothing. Everything
+below comes from outside that list — the point is to widen the funnel.
+
+Companies are never added to the watch list. Discovered positions go onto the
+board, and the morning report lists which companies produced them so a human can
+decide who is worth watching.
+
+Spend and politeness are bounded by construction:
+  * nothing is POSTed without --submit; the default is a dry run
+  * --max-submit caps paid calls per night (default 25)
+  * the seen-set is fetched first and every known dedupe key is skipped
+  * `force` is never sent, so a re-POST returns the cached analysis for free
+  * sources use official APIs/feeds, honour robots, and are rate-limited
+
+Usage:
+    python3 discover.py --gates ~/private/gates.txt --out ~/reports
+    python3 discover.py --gates ~/private/gates.txt --out ~/reports --submit
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter
+from pathlib import Path
+
+from fetch import compute_dedupe_key
+from llm import LlamaSwap
+from prescreen import Decision, Prescreener
+from report import write_reports
+from sources import SOURCES
+
+# No baked-in defaults for endpoints: this is a public toolkit and the
+# operator's job-store/LLM locations are theirs to supply (env or flag).
+DEFAULT_LLM = "http://localhost:8080"
+
+
+def http_json(url: str, payload: dict | None = None, timeout: int = 60):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(
+        url, data=data,
+        headers={"content-type": "application/json"} if data else {},
+        method="POST" if data else "GET",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode()
+        return json.loads(body) if body.strip() else {}
+
+
+def load_gates(path: str | None) -> str:
+    if not path:
+        raise SystemExit(
+            "--gates is required.\n\n"
+            "The prescreen cannot check deal-breakers without them, and job-store\n"
+            "keeps preferences server-side with no endpoint to read them. Point\n"
+            "--gates at a local file describing level band, location/timezone,\n"
+            "excluded role families and comp floor. Never commit it."
+        )
+    p = Path(path).expanduser()
+    if not p.is_file():
+        raise SystemExit(f"--gates: no such file: {p}")
+    return p.read_text()
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--backend", default=os.environ.get("JOB_STORE"),
+                    help="job-store base URL (env JOB_STORE)")
+    ap.add_argument("--llm", default=os.environ.get("LLAMA_SWAP", DEFAULT_LLM),
+                    help="OpenAI-compatible local LLM base URL (env LLAMA_SWAP)")
+    ap.add_argument("--gates", default=os.environ.get("GATES_PATH"))
+    ap.add_argument("--out", required=True,
+                    help="report dir — keep it somewhere durable, not scratch "
+                         "storage on the LLM host")
+    ap.add_argument("--triage-model", default=os.environ.get("TRIAGE_MODEL", "scorer"),
+                    help="model alias for the cheap triage stage (env TRIAGE_MODEL)")
+    ap.add_argument("--gate-model", default=os.environ.get("GATE_MODEL", "coder"),
+                    help="model alias for the gates+fit stage (env GATE_MODEL)")
+    ap.add_argument("--sources", default="hn,wwr",
+                    help=f"comma-separated: {','.join(SOURCES)}")
+    ap.add_argument("--submit", action="store_true",
+                    help="actually POST survivors for paid scoring (default: dry run)")
+    ap.add_argument("--max-submit", type=int, default=25)
+    ap.add_argument("--max-per-source", type=int, default=400)
+    # Match each model's -np slot count: scorer serves 8, coder serves 1.
+    ap.add_argument("--triage-workers", type=int, default=8)
+    ap.add_argument("--gate-workers", type=int, default=1)
+    args = ap.parse_args(argv)
+
+    outdir = Path(args.out).expanduser()
+    outdir.mkdir(parents=True, exist_ok=True)
+    gates_text = load_gates(args.gates)
+
+    if not args.backend:
+        ap.error("--backend (or env JOB_STORE) is required — your job-store URL")
+    print(f"[*] backend {args.backend}")
+    seen = set(http_json(f"{args.backend}/jobs/urls").get("dedupe_keys", []))
+    print(f"[*] seen-set: {len(seen)} dedupe keys")
+
+    resume = http_json(f"{args.backend}/resume")
+    resume_text = resume if isinstance(resume, str) else json.dumps(resume)
+
+    # Companies already watched: their roles are the poller's job, not ours.
+    watched = http_json(f"{args.backend}/companies.json")
+    if isinstance(watched, dict):
+        watched = watched.get("companies", [])
+    watched_names = {(c.get("name") or "").strip().lower() for c in watched}
+    print(f"[*] {len(watched_names)} companies already watched (their roles are the poller's job)")
+
+    # --- collect ---------------------------------------------------------
+    raw: list[dict] = []
+    errors: list[str] = []
+    for name in [s.strip() for s in args.sources.split(",") if s.strip()]:
+        mod = SOURCES.get(name)
+        if mod is None:
+            errors.append(f"unknown source {name!r}")
+            continue
+        try:
+            got = mod.collect(limit=args.max_per_source)
+            raw.extend(got)
+            print(f"[*] {name}: {len(got)} postings")
+        except Exception as err:
+            errors.append(f"{name}: {type(err).__name__}: {err}")
+            print(f"[!] {name}: {type(err).__name__}: {err}")
+
+    # --- dedupe ----------------------------------------------------------
+    fresh, skipped_seen, skipped_watched, dupes = [], 0, 0, 0
+    batch_keys: set[str] = set()
+    for p in raw:
+        key = compute_dedupe_key(p["url"])
+        if key in seen:
+            skipped_seen += 1
+            continue
+        if key in batch_keys:
+            dupes += 1
+            continue
+        if p.get("company", "").strip().lower() in watched_names:
+            skipped_watched += 1
+            continue
+        batch_keys.add(key)
+        fresh.append(p)
+
+    print(f"[*] {len(raw)} collected -> {len(fresh)} to screen "
+          f"({skipped_seen} already known, {skipped_watched} already watched, {dupes} dupes)")
+    if not fresh:
+        write_reports(outdir, [], [], errors, submitted=[], dry_run=not args.submit)
+        return 0
+
+    # --- prescreen (free) -------------------------------------------------
+    llm = LlamaSwap(args.llm)
+    screener = Prescreener(llm, gates_text=gates_text, resume_text=resume_text,
+                           triage_model=args.triage_model,
+                           screen_model=args.gate_model)
+
+    # Batched by stage: llama-swap holds ONE model, so screening postings
+    # individually swaps models twice per posting. See prescreen.screen_batch.
+    # Never lose a night's work to one bad request. A 20-minute run was lost to
+    # a single ConnectionResetError escaping the executor; whatever survives
+    # gets written either way.
+    try:
+        decisions = screener.screen_batch(
+            fresh,
+            triage_workers=args.triage_workers,
+            gate_workers=args.gate_workers,
+            progress=lambda m: print(f"[*] {m}"),
+        )
+    except BaseException as err:                     # includes KeyboardInterrupt
+        errors.append(f"prescreen aborted: {type(err).__name__}: {err}")
+        print(f"[!] prescreen aborted: {type(err).__name__}: {err}")
+        decisions = []
+    for d in sorted(decisions, key=lambda x: (not x.keep, x.company)):
+        print(f"    {'keep' if d.keep else 'drop':4} {d.company[:24]:24} "
+              f"{d.title[:44]:44} ({d.stage}: {d.reason[:44]})")
+
+    kept = [d for d in decisions if d.keep]
+    dropped = [d for d in decisions if not d.keep]
+    kept.sort(key=lambda d: d.detail.get("fit_sketch") or 0, reverse=True)
+    print(f"[*] kept {len(kept)}, dropped {len(dropped)}")
+
+    # --- submit (paid, capped) -------------------------------------------
+    by_url = {p["url"]: p for p in fresh}
+    submitted = []
+    if args.submit:
+        for d in kept[: args.max_submit]:
+            src = by_url.get(d.url, {})
+            payload = {
+                "url": d.url,
+                "description": src.get("description", ""),
+                "company": d.company,
+                "title": d.title,
+                "ats_platform": None,
+                "posted_at": src.get("posted_at"),
+                "discovered_by": f"overnight/{src.get('source', 'discovery')}",
+            }
+            try:
+                res = http_json(f"{args.backend}/jobs/score", payload, timeout=180)
+                submitted.append({"url": d.url, "title": d.title, "company": d.company,
+                                  "rank": res.get("rank"), "score": res.get("candidate_score")})
+                print(f"[$] {d.company} — {d.title[:44]} rank={res.get('rank')}")
+            except urllib.error.HTTPError as err:
+                print(f"[!] submit failed {d.url}: HTTP {err.code}")
+            except Exception as err:
+                print(f"[!] submit failed {d.url}: {err}")
+        if len(kept) > args.max_submit:
+            print(f"[*] cap reached: {len(kept) - args.max_submit} survivors not submitted")
+    else:
+        print(f"[*] DRY RUN — would submit {min(len(kept), args.max_submit)} of {len(kept)}")
+
+    # Companies worth a human look — never auto-added to the watch list.
+    new_co = Counter(d.company for d in kept if d.company)
+    if new_co:
+        errors.append("")  # spacer in the report
+        print("[*] companies producing keeps: " +
+              ", ".join(f"{c}({n})" for c, n in new_co.most_common(12)))
+
+    write_reports(outdir, kept, dropped, errors, submitted=submitted,
+                  dry_run=not args.submit, new_companies=new_co)
+    print(f"[*] reports -> {outdir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/job-board/overnight/discover.py
+++ b/job-board/overnight/discover.py
@@ -281,7 +281,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[*] DRY RUN — would submit {min(len(submittable), args.max_submit)} of {len(kept)}")
 
     # Companies worth a human look — never auto-added to the watch list.
-    new_co = Counter(d.company for d in kept if d.company)
+    # From submittable, not kept: a fail-open passthrough (stage=error) is not
+    # a role that survived the prescreen, and must not seed the shortlist.
+    new_co = Counter(d.company for d in submittable if d.company)
     if new_co:
         print("[*] companies producing keeps: " +
               ", ".join(f"{c}({n})" for c, n in new_co.most_common(12)))

--- a/job-board/overnight/discover.py
+++ b/job-board/overnight/discover.py
@@ -62,9 +62,10 @@ def seen_keys(payload: dict) -> set[str]:
     """The seen-set from GET /jobs/urls. Prefers dedupe_keys; falls back to
     computing keys from urls for older backends (same behavior as the
     poller's _seen_keys — this is the spend guardrail, so no silent empty)."""
-    keys = set(payload.get("dedupe_keys") or [])
+    keys = {k for k in payload.get("dedupe_keys") or [] if k}
     if not keys:
-        keys = {compute_dedupe_key(u) for u in payload.get("urls") or []}
+        keys = {k for k in (compute_dedupe_key(u)
+                            for u in payload.get("urls") or []) if k}
     return keys
 
 
@@ -151,7 +152,15 @@ def main(argv: list[str] | None = None) -> int:
     resume_text = resume if isinstance(resume, str) else json.dumps(resume)
 
     # Companies already watched: their roles are the poller's job, not ours.
-    watched = http_json(f"{args.backend}/companies.json")
+    # Non-fatal on failure: losing this only costs re-screening watched
+    # companies locally (the seen-set still dedupes anything already posted).
+    try:
+        watched = http_json(f"{args.backend}/companies.json")
+    except Exception as err:                            # noqa: BLE001
+        errors_boot.append(f"companies.json unavailable ({type(err).__name__}); "
+                           f"watched-company skip disabled tonight")
+        print(f"[!] {errors_boot[-1]}")
+        watched = []
     if isinstance(watched, dict):
         watched = watched.get("companies", [])
     watched_names = {(c.get("name") or "").strip().lower() for c in watched}
@@ -256,9 +265,12 @@ def main(argv: list[str] | None = None) -> int:
             }
             try:
                 res = http_json(f"{args.backend}/jobs/score", payload, timeout=180)
+                # Contract per job-store app.py's response_body: rank_score /
+                # fit_score at the top level (candidate_score only exists
+                # nested inside analysis).
                 submitted.append({"url": d.url, "title": d.title, "company": d.company,
-                                  "rank": res.get("rank"), "score": res.get("candidate_score")})
-                print(f"[$] {d.company} — {d.title[:44]} rank={res.get('rank')}")
+                                  "rank": res.get("rank_score"), "score": res.get("fit_score")})
+                print(f"[$] {d.company} — {d.title[:44]} rank={res.get('rank_score')}")
             except urllib.error.HTTPError as err:
                 print(f"[!] submit failed {d.url}: HTTP {err.code}")
             except Exception as err:

--- a/job-board/overnight/discover.py
+++ b/job-board/overnight/discover.py
@@ -175,7 +175,7 @@ def main(argv: list[str] | None = None) -> int:
             errors.append(f"unknown source {name!r}")
             continue
         try:
-            got = mod.collect(limit=args.max_per_source)
+            got = mod.collect(limit=args.max_per_source, problems=errors)
             raw.extend(got)
             print(f"[*] {name}: {len(got)} postings")
         except Exception as err:

--- a/job-board/overnight/discover.py
+++ b/job-board/overnight/discover.py
@@ -35,11 +35,13 @@ import urllib.request
 from collections import Counter
 from pathlib import Path
 
-# compute_dedupe_key lives in job-store's urls.py; import it directly rather
-# than via fetch, which would drag all six ATS adapter modules into the graph
-# just for this one function. fetch.py does the sys.path insert we rely on.
-import fetch  # noqa: F401  (performs the job-store sys.path insert)
-from urls import compute_dedupe_key
+# compute_dedupe_key lives in job-store's urls.py. Do the sys.path insert here
+# (the same one fetch.py does) and import urls DIRECTLY — importing via fetch
+# would pull all six ATS adapter modules into the graph for this one function.
+_JOB_STORE = Path(__file__).resolve().parent.parent / "job-store"
+if str(_JOB_STORE) not in sys.path:
+    sys.path.insert(0, str(_JOB_STORE))
+from urls import compute_dedupe_key  # noqa: E402
 from llm import LlamaSwap
 from prescreen import Decision, Prescreener
 from report import write_reports

--- a/job-board/overnight/discover.py
+++ b/job-board/overnight/discover.py
@@ -58,6 +58,16 @@ def http_json(url: str, payload: dict | None = None, timeout: int = 60):
         return json.loads(body) if body.strip() else {}
 
 
+def seen_keys(payload: dict) -> set[str]:
+    """The seen-set from GET /jobs/urls. Prefers dedupe_keys; falls back to
+    computing keys from urls for older backends (same behavior as the
+    poller's _seen_keys — this is the spend guardrail, so no silent empty)."""
+    keys = set(payload.get("dedupe_keys") or [])
+    if not keys:
+        keys = {compute_dedupe_key(u) for u in payload.get("urls") or []}
+    return keys
+
+
 def load_gates(path: str | None) -> str:
     if not path:
         raise SystemExit(
@@ -88,6 +98,12 @@ def main(argv: list[str] | None = None) -> int:
                     help="model alias for the cheap triage stage (env TRIAGE_MODEL)")
     ap.add_argument("--gate-model", default=os.environ.get("GATE_MODEL", "coder"),
                     help="model alias for the gates+fit stage (env GATE_MODEL)")
+    ap.add_argument("--title-drops-extra",
+                    default=os.environ.get("TITLE_DROPS_EXTRA"),
+                    help="comma-separated words/phrases to drop on sight in "
+                         "titles (env TITLE_DROPS_EXTRA) — your personal band/"
+                         "family exclusions live here or in the gates file, "
+                         "not in the code")
     ap.add_argument("--sources", default="hn,wwr",
                     help=f"comma-separated: {','.join(SOURCES)}")
     ap.add_argument("--submit", action="store_true",
@@ -106,10 +122,32 @@ def main(argv: list[str] | None = None) -> int:
     if not args.backend:
         ap.error("--backend (or env JOB_STORE) is required — your job-store URL")
     print(f"[*] backend {args.backend}")
-    seen = set(http_json(f"{args.backend}/jobs/urls").get("dedupe_keys", []))
+    seen_resp = http_json(f"{args.backend}/jobs/urls")
+    seen = seen_keys(seen_resp)
     print(f"[*] seen-set: {len(seen)} dedupe keys")
+    if not seen:
+        # Legitimate only on a brand-new board. On an established one this
+        # means dedupe is broken and every survivor would be re-submitted —
+        # the single most expensive failure this agent can have. Say so in
+        # the report, loudly.
+        errors_boot = ["seen-set is EMPTY — fine on a fresh board, otherwise "
+                       "dedupe is broken and paid re-scoring is likely"]
+        print(f"[!] {errors_boot[0]}")
+    else:
+        errors_boot = []
 
-    resume = http_json(f"{args.backend}/resume")
+    try:
+        resume = http_json(f"{args.backend}/resume")
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+            # 404 is the backend's documented answer when RESUME_PATH is
+            # unset server-side. Without a resume there is nothing to sketch
+            # fit against — fail with instructions, not a traceback.
+            print("[!] job-store has no resume configured (GET /resume -> 404). "
+                  "Set RESUME_PATH on the backend; the prescreen needs the "
+                  "resume text for fit sketches.", file=sys.stderr)
+            return 2
+        raise
     resume_text = resume if isinstance(resume, str) else json.dumps(resume)
 
     # Companies already watched: their roles are the poller's job, not ours.
@@ -121,7 +159,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # --- collect ---------------------------------------------------------
     raw: list[dict] = []
-    errors: list[str] = []
+    errors: list[str] = list(errors_boot)
     for name in [s.strip() for s in args.sources.split(",") if s.strip()]:
         mod = SOURCES.get(name)
         if mod is None:
@@ -162,7 +200,8 @@ def main(argv: list[str] | None = None) -> int:
     llm = LlamaSwap(args.llm)
     screener = Prescreener(llm, gates_text=gates_text, resume_text=resume_text,
                            triage_model=args.triage_model,
-                           screen_model=args.gate_model)
+                           screen_model=args.gate_model,
+                           title_drops_extra=args.title_drops_extra)
 
     # Batched by stage: llama-swap holds ONE model, so screening postings
     # individually swaps models twice per posting. See prescreen.screen_batch.
@@ -189,11 +228,22 @@ def main(argv: list[str] | None = None) -> int:
     kept.sort(key=lambda d: d.detail.get("fit_sketch") or 0, reverse=True)
     print(f"[*] kept {len(kept)}, dropped {len(dropped)}")
 
+    # Fail-open keeps a posting IN THE REPORT, never in the paid queue: a
+    # gate-model outage must not convert --max-submit slots into unscreened
+    # Anthropic calls. They're listed for the human instead.
+    submittable = [d for d in kept if d.stage != "error"]
+    error_kept = len(kept) - len(submittable)
+    if error_kept:
+        msg = (f"{error_kept} posting(s) kept via screen-failure passthrough — "
+               f"in the report for human review, EXCLUDED from paid submission")
+        errors.append(msg)
+        print(f"[!] {msg}")
+
     # --- submit (paid, capped) -------------------------------------------
     by_url = {p["url"]: p for p in fresh}
     submitted = []
     if args.submit:
-        for d in kept[: args.max_submit]:
+        for d in submittable[: args.max_submit]:
             src = by_url.get(d.url, {})
             payload = {
                 "url": d.url,
@@ -213,15 +263,14 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"[!] submit failed {d.url}: HTTP {err.code}")
             except Exception as err:
                 print(f"[!] submit failed {d.url}: {err}")
-        if len(kept) > args.max_submit:
-            print(f"[*] cap reached: {len(kept) - args.max_submit} survivors not submitted")
+        if len(submittable) > args.max_submit:
+            print(f"[*] cap reached: {len(submittable) - args.max_submit} survivors not submitted")
     else:
-        print(f"[*] DRY RUN — would submit {min(len(kept), args.max_submit)} of {len(kept)}")
+        print(f"[*] DRY RUN — would submit {min(len(submittable), args.max_submit)} of {len(kept)}")
 
     # Companies worth a human look — never auto-added to the watch list.
     new_co = Counter(d.company for d in kept if d.company)
     if new_co:
-        errors.append("")  # spacer in the report
         print("[*] companies producing keeps: " +
               ", ".join(f"{c}({n})" for c, n in new_co.most_common(12)))
 

--- a/job-board/overnight/fetch.py
+++ b/job-board/overnight/fetch.py
@@ -1,0 +1,96 @@
+"""Rate-limited wrapper around the existing ATS adapters.
+
+The adapters in `job-store/adapters/` are pure fetch functions and are reused
+verbatim — this module does not reimplement any scraping. What it adds is the
+politeness the overnight brief requires and the poller does not currently
+implement:
+
+  - a minimum delay between requests to the same host
+  - no parallelism per host (fetching is strictly serial)
+  - a circuit breaker that stops hitting a host after repeated 403/429
+
+That last one is not theoretical: the Workday scrapers tripped bot detection
+once already. A nightly job that retries into a block turns a one-off into a
+pattern, so the breaker is deliberately trigger-happy — it gives up on a host
+for the rest of the run and reports it, rather than backing off and trying again.
+"""
+
+from __future__ import annotations
+
+import random
+import sys
+import time
+import urllib.error
+import urllib.parse
+from pathlib import Path
+
+# Reuse the job-store adapters rather than writing new scrapers.
+_JOB_STORE = Path(__file__).resolve().parent.parent / "job-store"
+if str(_JOB_STORE) not in sys.path:
+    sys.path.insert(0, str(_JOB_STORE))
+
+from adapters import ADAPTERS  # noqa: E402
+from urls import compute_dedupe_key  # noqa: E402
+
+__all__ = ["ADAPTERS", "compute_dedupe_key", "PoliteFetcher", "HostBlocked"]
+
+
+class HostBlocked(RuntimeError):
+    """Raised when a host has refused us enough times to stop for the night."""
+
+
+class PoliteFetcher:
+    def __init__(self, *, min_delay: float = 3.0, jitter: float = 1.5, block_after: int = 3):
+        self.min_delay = min_delay
+        self.jitter = jitter
+        self.block_after = block_after
+        self._last_hit: dict[str, float] = {}
+        self._refusals: dict[str, int] = {}
+        self.blocked: set[str] = set()
+
+    @staticmethod
+    def _host(url: str) -> str:
+        try:
+            return urllib.parse.urlparse(url).netloc.lower()
+        except Exception:
+            return url
+
+    def _wait(self, host: str) -> None:
+        last = self._last_hit.get(host)
+        if last is not None:
+            elapsed = time.monotonic() - last
+            delay = self.min_delay + random.uniform(0, self.jitter)
+            if elapsed < delay:
+                time.sleep(delay - elapsed)
+        self._last_hit[host] = time.monotonic()
+
+    def _note_refusal(self, host: str) -> None:
+        self._refusals[host] = self._refusals.get(host, 0) + 1
+        if self._refusals[host] >= self.block_after:
+            self.blocked.add(host)
+
+    def list_jobs(self, platform: str, identifier: dict, *, careers_url: str = "") -> list[dict]:
+        """Fetch a board's postings, serially and politely.
+
+        Returns the adapter's list of {url, title, description, ...}. Raises
+        HostBlocked if this host has already refused us too often tonight.
+        """
+        adapter = ADAPTERS.get(platform)
+        if adapter is None:
+            raise ValueError(f"no adapter for ats_platform={platform!r}")
+
+        host = self._host(careers_url) or platform
+        if host in self.blocked:
+            raise HostBlocked(f"{host}: skipped, refused {self._refusals.get(host, 0)}x tonight")
+
+        self._wait(host)
+        try:
+            return adapter.list_jobs(identifier) or []
+        except urllib.error.HTTPError as err:
+            if err.code in (403, 429):
+                self._note_refusal(host)
+                if host in self.blocked:
+                    raise HostBlocked(
+                        f"{host}: HTTP {err.code} {self._refusals[host]}x — stopping for tonight"
+                    ) from err
+            raise

--- a/job-board/overnight/fetch.py
+++ b/job-board/overnight/fetch.py
@@ -36,7 +36,13 @@ __all__ = ["ADAPTERS", "compute_dedupe_key", "PoliteFetcher", "HostBlocked"]
 
 
 class HostBlocked(RuntimeError):
-    """Raised when a host has refused us enough times to stop for the night."""
+    """Raised when a host has refused us enough times to stop for the night.
+
+    Note: `sources.HostBlocked` is a SEPARATE class with the same name for the
+    raw-feed fetch path. They are not interchangeable in `except` clauses; each
+    is caught within its own fetch layer (sources catch theirs inside
+    `collect()`), so neither escapes to a caller expecting the other.
+    """
 
 
 class PoliteFetcher:

--- a/job-board/overnight/fetch.py
+++ b/job-board/overnight/fetch.py
@@ -1,5 +1,13 @@
 """Rate-limited wrapper around the existing ATS adapters.
 
+NOT CURRENTLY WIRED. The shipped sources (hn, wwr) fetch raw APIs/RSS through
+`sources.polite_get`, which has its own per-host delay + breaker, so nothing
+imports this module yet. It's kept as the seam for a future adapter-based
+source (the design premise that the overnight agent reuses job-store's
+adapters rather than writing new scrapers). If it's still unused when a
+second source lands, delete it.
+
+
 The adapters in `job-store/adapters/` are pure fetch functions and are reused
 verbatim — this module does not reimplement any scraping. What it adds is the
 politeness the overnight brief requires and the poller does not currently

--- a/job-board/overnight/gates.example.txt
+++ b/job-board/overnight/gates.example.txt
@@ -1,0 +1,39 @@
+# Example gates file for --gates / $GATES_PATH.
+#
+# COPY THIS SOMEWHERE PRIVATE AND EDIT IT. Do not commit the real one — it is
+# personal data, and this repo is public. job-store keeps the authoritative
+# preferences server-side (PREFERENCES_PATH); this is the local prescreen's copy
+# so it can drop obvious misses without a paid call.
+#
+# The file is read as plain text and pasted into the system prompt, so the format
+# is whatever a model reads well. Prose beats YAML here. What matters is that
+# each line states something the model can check against quoted posting text.
+#
+# Write deal-breakers, not preferences. Every line here can DROP a job, and a
+# gate that fires wrongly costs a real opportunity — the morning report has a
+# "dropped on gates" section precisely so you can audit for that.
+#
+# Everything below describes an INVENTED example candidate. Replace all of it
+# with your own deal-breakers.
+
+- Level: mid-to-senior individual contributor. Nothing requiring prior
+  team-lead or people-management experience.
+
+- Location: remote within European time zones, or hybrid within commuting
+  distance of Rotterdam. Relocation requirements are a hard fail.
+
+- Excluded role families:
+  - Consulting or agency work billed by the hour
+  - Primarily embedded/firmware work
+  - Roles where most of the work is stakeholder reporting
+
+- Required background: the example candidate is a backend engineer (Go,
+  PostgreSQL, event-driven systems). A posting that lists deep expertise in an
+  unrelated stack as REQUIRED — not "nice to have" — is a fail.
+
+- Compensation: if a range is published and its top is below the candidate's
+  floor, fail. If no range is published, this gate does not fire.
+
+# Reminder for whoever edits this: ambiguity is NOT a failure. If the posting
+# does not say, the gate does not fire. The prompt says so too, but the wording
+# of these lines is what the model actually reasons over — keep them checkable.

--- a/job-board/overnight/llm.py
+++ b/job-board/overnight/llm.py
@@ -1,0 +1,190 @@
+"""llama-swap client for grammar-constrained JSON.
+
+Everything here exists to make the local model emit JSON that always parses and
+always matches the schema, so the prescreen never has to guess at malformed
+output at 3am.
+
+Two hard-won details, both verified against the box on 2026-08-02:
+
+1. `chat_template_kwargs={"enable_thinking": false}` is REQUIRED. Without it the
+   Qwen models emit a `reasoning_content` block, burn the whole token budget on
+   it, and return `content: ""` with `finish_reason: "length"`. It fails as an
+   empty string, not as an error, so it is easy to mistake for a bad prompt.
+
+2. Schema property ORDER matters. Grammar-constrained decoding emits fields in
+   schema order, so putting `evidence`/`gaps` before `score` forces the model to
+   commit to its reasoning before the number. Same design as the cloud scorer.
+   Keep score fields last when you edit SCHEMAS.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_ENDPOINT = "http://localhost:8080"
+
+# llama-swap starts a model on first request; a cold MoE off spinning rust can
+# take minutes (the server's own healthCheckTimeout is 900s).
+COLD_START_TIMEOUT = 900
+WARM_TIMEOUT = 180
+
+
+class LLMError(RuntimeError):
+    pass
+
+
+class LlamaSwap:
+    def __init__(self, endpoint: str = DEFAULT_ENDPOINT, *, timeout: int | None = None):
+        self.endpoint = endpoint.rstrip("/")
+        self.timeout = timeout or COLD_START_TIMEOUT
+        self._warm: set[str] = set()
+
+    def models(self) -> list[str]:
+        req = urllib.request.Request(f"{self.endpoint}/v1/models")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return [m["id"] for m in json.load(resp).get("data", [])]
+
+    def json_call(
+        self,
+        model: str,
+        system: str,
+        user: str,
+        schema: dict,
+        *,
+        max_tokens: int = 1200,
+        temperature: float = 0.0,
+        seed: int | None = 42,
+        retries: int = 2,
+    ) -> dict:
+        """One grammar-constrained call. Returns the parsed object.
+
+        Raises LLMError rather than returning junk: a prescreen that silently
+        degrades is worse than one that stops and says so in the morning report.
+        """
+        body = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            # See module docstring — without this, content comes back empty.
+            "chat_template_kwargs": {"enable_thinking": False},
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "prescreen", "strict": True, "schema": schema},
+            },
+        }
+        if seed is not None:
+            body["seed"] = seed
+
+        timeout = WARM_TIMEOUT if model in self._warm else self.timeout
+        last_err: Exception | None = None
+
+        for attempt in range(retries + 1):
+            try:
+                req = urllib.request.Request(
+                    f"{self.endpoint}/v1/chat/completions",
+                    data=json.dumps(body).encode(),
+                    headers={"content-type": "application/json"},
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    payload = json.load(resp)
+
+                self._warm.add(model)
+                timeout = WARM_TIMEOUT
+
+                choice = payload["choices"][0]
+                content = choice["message"].get("content") or ""
+                finish = choice.get("finish_reason")
+
+                if finish == "length" and not content.strip():
+                    raise LLMError(
+                        f"{model}: empty content with finish_reason=length. The "
+                        "thinking block ate the budget — check that "
+                        "chat_template_kwargs.enable_thinking is still being honoured."
+                    )
+                if not content.strip():
+                    raise LLMError(f"{model}: empty content (finish_reason={finish})")
+
+                return json.loads(content)
+
+            # OSError covers ConnectionResetError and URLError (both subclass it).
+            # Catching only URLError let a single reset-by-peer kill a 20-minute
+            # run and lose every screened posting — do not narrow this.
+            except (OSError, TimeoutError, json.JSONDecodeError, KeyError, LLMError) as err:
+                last_err = err
+                if attempt < retries:
+                    time.sleep(2 * (attempt + 1))
+
+        raise LLMError(f"{model}: failed after {retries + 1} attempts: {last_err}")
+
+
+# --- Schemas ---------------------------------------------------------------
+# Field order is load-bearing. Reasoning fields first, score last.
+
+TRIAGE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title_evidence": {
+            "type": "string",
+            "description": "The exact title text you are judging.",
+        },
+        "family": {
+            "type": "string",
+            "enum": [
+                "platform", "devops", "build-release", "developer-experience",
+                "infrastructure", "sre", "management", "frontend", "other",
+            ],
+        },
+        "level": {
+            "type": "string",
+            "enum": ["below-senior", "senior", "staff-plus", "management", "unclear"],
+        },
+        "keep": {"type": "boolean"},
+        "reason": {"type": "string"},
+    },
+    "required": ["title_evidence", "family", "level", "keep", "reason"],
+    "additionalProperties": False,
+}
+
+GATE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "gate_failures": {
+            "type": "array",
+            "description": (
+                "HARD deal-breakers this posting CLEARLY fails. Quote the posting. "
+                "Ambiguity is NOT a failure — omit anything you cannot quote."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "gate": {"type": "string"},
+                    "evidence": {"type": "string"},
+                },
+                "required": ["gate", "evidence"],
+                "additionalProperties": False,
+            },
+        },
+        "strong_matches": {"type": "array", "items": {"type": "string"}},
+        "required_misses": {"type": "array", "items": {"type": "string"}},
+        "pace_signals": {
+            "type": "array",
+            "description": "Each prefixed 'RED: ' or 'GREEN: '.",
+            "items": {"type": "string"},
+        },
+        "fit_sketch": {"type": "integer", "minimum": 0, "maximum": 100},
+        "worth_paid_scoring": {"type": "boolean"},
+    },
+    "required": [
+        "gate_failures", "strong_matches", "required_misses",
+        "pace_signals", "fit_sketch", "worth_paid_scoring",
+    ],
+    "additionalProperties": False,
+}

--- a/job-board/overnight/llm.py
+++ b/job-board/overnight/llm.py
@@ -36,6 +36,17 @@ class LLMError(RuntimeError):
     pass
 
 
+def _is_timeout(err: Exception) -> bool:
+    """True for read- AND connect-phase timeouts. urllib re-wraps a
+    connect-phase socket timeout as URLError(reason=socket.timeout), which is
+    NOT a TimeoutError — missing that let a dropped-SYN path (firewall DROP,
+    dead tunnel) reproduce the 37-hour hang the model breaker exists to stop."""
+    if isinstance(err, TimeoutError):
+        return True
+    reason = getattr(err, "reason", None)
+    return isinstance(reason, TimeoutError)
+
+
 class LlamaSwap:
     def __init__(self, endpoint: str = DEFAULT_ENDPOINT, *, timeout: int | None = None,
                  dead_after: int = 2):
@@ -135,7 +146,7 @@ class LlamaSwap:
                 last_err = err
                 # A timeout (socket.timeout subclasses TimeoutError AND OSError)
                 # is the expensive failure — count it toward the model breaker.
-                if isinstance(err, TimeoutError):
+                if _is_timeout(err):
                     self._timeouts[model] = self._timeouts.get(model, 0) + 1
                     if self._timeouts[model] >= self.dead_after:
                         self._dead.add(model)

--- a/job-board/overnight/llm.py
+++ b/job-board/overnight/llm.py
@@ -110,7 +110,9 @@ class LlamaSwap:
         timeout = WARM_TIMEOUT if model in self._warm else self.timeout
         last_err: Exception | None = None
 
+        attempts = 0
         for attempt in range(retries + 1):
+            attempts = attempt + 1
             try:
                 req = urllib.request.Request(
                     f"{self.endpoint}/v1/chat/completions",
@@ -154,7 +156,7 @@ class LlamaSwap:
                 if attempt < retries:
                     time.sleep(2 * (attempt + 1))
 
-        raise LLMError(f"{model}: failed after {retries + 1} attempts: {last_err}")
+        raise LLMError(f"{model}: failed after {attempts} attempt(s): {last_err}")
 
 
 # --- Schemas ---------------------------------------------------------------

--- a/job-board/overnight/llm.py
+++ b/job-board/overnight/llm.py
@@ -37,10 +37,21 @@ class LLMError(RuntimeError):
 
 
 class LlamaSwap:
-    def __init__(self, endpoint: str = DEFAULT_ENDPOINT, *, timeout: int | None = None):
+    def __init__(self, endpoint: str = DEFAULT_ENDPOINT, *, timeout: int | None = None,
+                 dead_after: int = 2):
         self.endpoint = endpoint.rstrip("/")
         self.timeout = timeout or COLD_START_TIMEOUT
         self._warm: set[str] = set()
+        # Per-model circuit breaker on TIMEOUTS. --max-submit bounds the money,
+        # but nothing bounded the wall clock: a hung llama-swap costs one full
+        # COLD_START_TIMEOUT per posting (~45 min), so 400 postings could run
+        # 37+ hours into the next night's cron. After `dead_after` timeouts a
+        # model is declared dead and every later call fails fast — the run ends
+        # in minutes with a report full of screen-failures (fail-open =>
+        # stage=error => never a paid call), instead of grinding for a day.
+        self.dead_after = dead_after
+        self._timeouts: dict[str, int] = {}
+        self._dead: set[str] = set()
 
     def models(self) -> list[str]:
         req = urllib.request.Request(f"{self.endpoint}/v1/models")
@@ -82,6 +93,9 @@ class LlamaSwap:
         if seed is not None:
             body["seed"] = seed
 
+        if model in self._dead:
+            raise LLMError(f"{model}: declared dead after {self.dead_after} "
+                           f"timeouts tonight; not retrying")
         timeout = WARM_TIMEOUT if model in self._warm else self.timeout
         last_err: Exception | None = None
 
@@ -119,6 +133,13 @@ class LlamaSwap:
             # run and lose every screened posting — do not narrow this.
             except (OSError, TimeoutError, json.JSONDecodeError, KeyError, LLMError) as err:
                 last_err = err
+                # A timeout (socket.timeout subclasses TimeoutError AND OSError)
+                # is the expensive failure — count it toward the model breaker.
+                if isinstance(err, TimeoutError):
+                    self._timeouts[model] = self._timeouts.get(model, 0) + 1
+                    if self._timeouts[model] >= self.dead_after:
+                        self._dead.add(model)
+                        break
                 if attempt < retries:
                     time.sleep(2 * (attempt + 1))
 

--- a/job-board/overnight/prescreen.py
+++ b/job-board/overnight/prescreen.py
@@ -190,6 +190,9 @@ class Prescreener:
         self.llm = llm
         self.triage_model = triage_model
         self.screen_model = screen_model
+        # Set here (not just in screen_batch) so _triage never discards a
+        # failure into a throwaway list on the single-posting screen() path.
+        self._triage_errors: list[str] = []
         # The CLI (discover.py) resolves $TITLE_DROPS_EXTRA into the flag;
         # reading env here too would make direct construction (tests, library
         # use) inherit ambient state from the operator's shell.
@@ -225,7 +228,7 @@ class Prescreener:
         # list.append is atomic under the GIL, so triage workers can record
         # here without a lock. Gate failures are already visible (stage=error
         # in the report); triage failures were the last silent degradation.
-        self._triage_errors: list[str] = []
+        self._triage_errors = []           # reset per batch
         self._stage2_count = 0
 
         # Stage 1 — free.
@@ -293,7 +296,7 @@ class Prescreener:
             # Fail open — a model problem must not shrink the funnel — but
             # record it so a dead triage model shows up in the report instead
             # of masquerading as "classified everything as keep".
-            getattr(self, "_triage_errors", []).append(
+            self._triage_errors.append(
                 f"triage model {self.triage_model!r} failed: "
                 f"{type(err).__name__}: {err}")
             return None, True

--- a/job-board/overnight/prescreen.py
+++ b/job-board/overnight/prescreen.py
@@ -148,11 +148,9 @@ _GENERIC_TITLE_DROPS = re.compile(
     r"\b(intern|internship|apprentice|new[- ]grad)\b", re.I)
 _SENIOR_HINT = re.compile(r"\b(senior|sr\.?|lead)\b", re.I)
 
-# job-store scores nothing below this description length; a shorter posting
-# would burn two local model calls, eat a submit slot, and upsert unscored.
-# Enforced in stage 1 for EVERY source (HN filters at collection too; WWR and
-# any future source get the floor here).
-MIN_DESCRIPTION = 100
+# The backend's scoring floor, shared across sources and the prescreen so the
+# number lives in one place (sources.MIN_DESCRIPTION_CHARS).
+from sources import MIN_DESCRIPTION_CHARS as MIN_DESCRIPTION
 
 
 def build_title_drops(extra: str | None) -> re.Pattern | None:
@@ -211,16 +209,23 @@ class Prescreener:
         triage_workers: int = 8,
         gate_workers: int = 1,
         progress=None,
+        problems: list[str] | None = None,
     ) -> list[Decision]:
         """Screen many postings with exactly two model loads.
 
         triage_workers/gate_workers should match each model's `-np` slot count:
-        scorer serves 8, coder serves 1.
+        scorer serves 8, coder serves 1. `problems` (if given) collects
+        run-degradation notes for the morning report — currently triage
+        failures, which otherwise pass through to the full screen invisibly.
         """
         import concurrent.futures as cf
 
         decisions: list[Decision] = []
         stage2: list[dict] = []
+        # list.append is atomic under the GIL, so triage workers can record
+        # here without a lock. Gate failures are already visible (stage=error
+        # in the report); triage failures were the last silent degradation.
+        self._triage_errors: list[str] = []
 
         # Stage 1 — free.
         for p in postings:
@@ -252,6 +257,11 @@ class Prescreener:
                         decisions.append(d)
         if progress:
             progress(f"triage: {len(stage2) - len(stage3)} dropped, {len(stage3)} to full screen")
+        if self._triage_errors and problems is not None:
+            # One deduped line per failing model, not 400 — a dead triage
+            # model must be visible, not spammy.
+            for msg in sorted(set(self._triage_errors)):
+                problems.append(msg)
 
         # Stage 3 — coder resident for the whole stage.
         if stage3:
@@ -274,8 +284,14 @@ class Prescreener:
                 f"Title: {title}\nCompany: {p.get('company','')}", TRIAGE_SCHEMA,
                 max_tokens=400,
             )
-        except Exception:
-            return None, True  # fail open — a model problem must not shrink the funnel
+        except Exception as err:
+            # Fail open — a model problem must not shrink the funnel — but
+            # record it so a dead triage model shows up in the report instead
+            # of masquerading as "classified everything as keep".
+            getattr(self, "_triage_errors", []).append(
+                f"triage model {self.triage_model!r} failed: "
+                f"{type(err).__name__}: {err}")
+            return None, True
 
         # Decide on the CLASSIFICATION, not on the model's `keep` boolean.
         # Trusting `keep` made triage drop 0 of 33 on a live run — the model

--- a/job-board/overnight/prescreen.py
+++ b/job-board/overnight/prescreen.py
@@ -34,7 +34,6 @@ substitute for the authoritative score.
 
 from __future__ import annotations
 
-import os
 import re
 from dataclasses import dataclass, field
 
@@ -149,6 +148,12 @@ _GENERIC_TITLE_DROPS = re.compile(
     r"\b(intern|internship|apprentice|new[- ]grad)\b", re.I)
 _SENIOR_HINT = re.compile(r"\b(senior|sr\.?|lead)\b", re.I)
 
+# job-store scores nothing below this description length; a shorter posting
+# would burn two local model calls, eat a submit slot, and upsert unscored.
+# Enforced in stage 1 for EVERY source (HN filters at collection too; WWR and
+# any future source get the floor here).
+MIN_DESCRIPTION = 100
+
 
 def build_title_drops(extra: str | None) -> re.Pattern | None:
     """Compile TITLE_DROPS_EXTRA / --title-drops-extra: comma-separated
@@ -222,11 +227,13 @@ class Prescreener:
             title = (p.get("title") or "").strip()
             base = dict(url=p.get("url", ""), title=title, company=p.get("company", ""))
             ok, why = rules_stage(title, self.extra_drops)
+            jd = (p.get("description") or "").strip()
             if not ok:
                 decisions.append(Decision(**base, keep=False, stage="rules", reason=why))
-            elif not (p.get("description") or "").strip():
+            elif len(jd) < MIN_DESCRIPTION:
                 decisions.append(Decision(**base, keep=False, stage="rules",
-                                          reason="empty description"))
+                                          reason=f"description too short "
+                                                 f"({len(jd)} chars, min {MIN_DESCRIPTION})"))
             else:
                 stage2.append(p)
 
@@ -336,8 +343,10 @@ class Prescreener:
         if not ok:
             return Decision(**base, keep=False, stage="rules", reason=why)
 
-        if not jd:
-            return Decision(**base, keep=False, stage="rules", reason="empty description")
+        if len(jd) < MIN_DESCRIPTION:
+            return Decision(**base, keep=False, stage="rules",
+                            reason=f"description too short ({len(jd)} chars, "
+                                   f"min {MIN_DESCRIPTION})")
 
         # Stage 2 — title triage on the small GPU-resident model.
         try:

--- a/job-board/overnight/prescreen.py
+++ b/job-board/overnight/prescreen.py
@@ -114,7 +114,10 @@ class Decision:
     title: str
     company: str
     keep: bool
-    stage: str                      # rules | triage | gates | kept
+    stage: str                      # rules | triage | gates | kept | error
+                                    # ("error" = fail-open passthrough: shown
+                                    # in the report, NEVER submitted for paid
+                                    # scoring — discover.py filters on it)
     reason: str
     detail: dict = field(default_factory=dict)
 

--- a/job-board/overnight/prescreen.py
+++ b/job-board/overnight/prescreen.py
@@ -1,0 +1,371 @@
+"""Local prescreen: decide what deserves a paid scoring call.
+
+This is a PRESCREEN, never an authoritative score. It never writes scores into
+job-store. Its only output is a keep/drop decision plus the evidence behind it,
+so that the paid Anthropic call is spent on plausible roles instead of junk.
+
+Three stages, cheapest first, each able to drop a posting:
+
+  1. rules      — deterministic title/keyword checks. No model, no tokens.
+  2. triage     — small all-VRAM model on the title only.
+  3. gates+fit  — the MoE scorer on the full JD, mirroring the cloud scorer's
+                  shape: evidence first, gates as quoted evidence, score last.
+
+STAGES ARE BATCHED, AND THAT IS NOT AN OPTIMISATION — IT IS REQUIRED.
+llama-swap keeps exactly one model resident (8 GB of VRAM cannot hold the 5.2 GB
+triage model and the MoE's 4.9 GB of attention+KV at once). Screening postings
+one at a time therefore swaps models twice per posting, and a cold MoE load off
+a spinning disk costs minutes. Measured: a 28-posting run made no progress in
+four minutes of thrashing.
+
+So `screen_batch()` runs every triage call, then every gate call — two model
+loads for the whole night instead of two per job. Use it. `screen()` remains for
+single-posting testing only.
+
+Concurrency is per-stage because the slot counts differ: `scorer` serves `-np 8`,
+while `coder` is `-np 1` (it was dropped to a single slot so Claude Code gets the
+full context window). Sending 4 concurrent requests to a 1-slot server just
+queues them.
+
+Local absolute scores compress toward the middle, so `fit_sketch` is used only
+as a coarse threshold and for ranking within a night's batch — never as a
+substitute for the authoritative score.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from llm import GATE_SCHEMA, TRIAGE_SCHEMA, LlamaSwap, LLMError
+
+TRIAGE_SYSTEM = """You CLASSIFY job titles. You do not decide whether to keep them.
+
+Assign the single closest `family`:
+  platform             - platform engineering, internal platforms
+  devops               - devops, cloud/infrastructure automation
+  build-release        - build, release, CI/CD engineering
+  developer-experience - devex, developer productivity, tooling
+  infrastructure       - infrastructure, systems, sysadmin
+  sre                  - site reliability, on-call ownership as the core
+  management           - manager, director, head, lead-of-people
+  frontend             - frontend, UI, mobile
+  other                - EVERYTHING ELSE: AI/ML, data, security, sales,
+                         marketing, support, product, full-stack, founder,
+                         developer relations/advocacy, solutions architect
+
+Assign `level` from the title's own wording: below-senior, senior, staff-plus,
+management, or unclear when the title says nothing about level.
+
+Be decisive about `family` — "other" is the correct answer for most titles and
+is not a rejection. Set `keep` to your honest read, but the classification is
+what matters; the caller applies its own policy.
+
+Judge ONLY the title given. Quote it in title_evidence."""
+
+GATE_SYSTEM_TMPL = """You prescreen job postings against a candidate's hard requirements.
+
+You are the cheap wide funnel. A human and a more expensive model make the real
+decision. Your job is to discard only what CLEARLY fails, and to show your work.
+
+RULES:
+- A gate may fire ONLY on evidence you can quote from the posting. Quote it.
+- Ambiguity is NOT a failure. Silence in a posting is NOT a failure. If the
+  posting does not say, the gate does not fire.
+- List evidence and gaps BEFORE deciding. Do not reason after the number.
+- `worth_paid_scoring` is false only when a gate fired or the role is plainly
+  irrelevant. When in doubt, say true — a wasted scoring call is cheaper than a
+  missed job.
+
+FIELD RUBRICS. Follow these literally; do not leave a field at its default.
+
+`fit_sketch` is an integer 0-100 for evidence-weighted skill match:
+    0-20   no meaningful overlap with the candidate's background
+    21-45  adjacent, but the posting's named tools are mostly absent
+    46-70  solid partial match; some named tools present
+    71-85  strong; most named tools appear in the candidate's background
+    86-100 excellent; the posting names tools the candidate has used directly
+  Use the FULL range. Never default to 0 — 0 means "no overlap whatsoever" and
+  is almost never correct for a role in the candidate's own field.
+
+`pace_signals` describe THE POSTING AND THE COMPANY, not the candidate's resume.
+  Every entry MUST begin with exactly "RED: " or "GREEN: ".
+    RED:   grind/intensity tells — "fast-paced", "wear many hats", "hyper-growth",
+           "24/7 ownership", crunch or always-on language
+    GREEN: structural rest — minimum/mandatory PTO, shutdown weeks, profitability,
+           long median tenure, no-meeting days
+  Structural facts outrank aspirational copy. Empty array if the posting says
+  nothing eitherway.
+
+`strong_matches` / `required_misses` compare the posting's stated requirements
+  against the candidate's background. Quote the posting's wording.
+
+THE CANDIDATE'S HARD REQUIREMENTS:
+{gates}
+
+THE CANDIDATE'S BACKGROUND:
+{resume}"""
+
+
+@dataclass
+class Decision:
+    url: str
+    title: str
+    company: str
+    keep: bool
+    stage: str                      # rules | triage | gates | kept
+    reason: str
+    detail: dict = field(default_factory=dict)
+
+    def row(self) -> dict:
+        return {
+            "company": self.company,
+            "title": self.title,
+            "url": self.url,
+            "keep": self.keep,
+            "stage": self.stage,
+            "reason": self.reason,
+            "fit_sketch": self.detail.get("fit_sketch"),
+            "gates": "; ".join(
+                f"{g.get('gate')}: {g.get('evidence','')[:120]}"
+                for g in self.detail.get("gate_failures", [])
+            ),
+        }
+
+
+# Stage 1 — deterministic. Cheapest possible rejection.
+_HARD_TITLE_DROPS = re.compile(
+    r"\b(intern|internship|junior|jr\.?|associate|apprentice|"
+    r"manager|director|head of|vp\b|vice president|chief|"
+    r"principal|staff|distinguished|fellow|"
+    r"recruiter|sales|marketing|designer|"
+    r"front[- ]?end|mobile|ios|android|"
+    r"data scientist|machine learning engineer)\b",
+    re.I,
+)
+_SENIOR_HINT = re.compile(r"\b(senior|sr\.?|lead)\b", re.I)
+
+
+def rules_stage(title: str) -> tuple[bool, str]:
+    t = (title or "").strip()
+    if not t:
+        return False, "no title"
+    m = _HARD_TITLE_DROPS.search(t)
+    if m:
+        return False, f"title contains {m.group(0)!r}"
+    return True, ""
+
+
+class Prescreener:
+    def __init__(
+        self,
+        llm: LlamaSwap,
+        *,
+        gates_text: str,
+        resume_text: str,
+        triage_model: str = "scorer",
+        screen_model: str = "coder",
+        fit_floor: int = 25,
+        max_jd_chars: int = 24000,
+    ):
+        self.llm = llm
+        self.triage_model = triage_model
+        self.screen_model = screen_model
+        self.fit_floor = fit_floor
+        self.max_jd_chars = max_jd_chars
+        self.gate_system = GATE_SYSTEM_TMPL.format(
+            gates=gates_text.strip(), resume=resume_text.strip()
+        )
+
+    # --- batched: one model load per stage, not per posting -----------------
+
+    def screen_batch(
+        self,
+        postings: list[dict],
+        *,
+        triage_workers: int = 8,
+        gate_workers: int = 1,
+        progress=None,
+    ) -> list[Decision]:
+        """Screen many postings with exactly two model loads.
+
+        triage_workers/gate_workers should match each model's `-np` slot count:
+        scorer serves 8, coder serves 1.
+        """
+        import concurrent.futures as cf
+
+        decisions: list[Decision] = []
+        stage2: list[dict] = []
+
+        # Stage 1 — free.
+        for p in postings:
+            title = (p.get("title") or "").strip()
+            base = dict(url=p.get("url", ""), title=title, company=p.get("company", ""))
+            ok, why = rules_stage(title)
+            if not ok:
+                decisions.append(Decision(**base, keep=False, stage="rules", reason=why))
+            elif not (p.get("description") or "").strip():
+                decisions.append(Decision(**base, keep=False, stage="rules",
+                                          reason="empty description"))
+            else:
+                stage2.append(p)
+
+        if progress:
+            progress(f"rules: {len(postings) - len(stage2)} dropped, {len(stage2)} to triage")
+
+        # Stage 2 — scorer resident for the whole stage.
+        stage3: list[dict] = []
+        if stage2:
+            with cf.ThreadPoolExecutor(max_workers=triage_workers) as pool:
+                for p, res in zip(stage2, pool.map(self._triage, stage2)):
+                    d, passed = res
+                    if passed:
+                        stage3.append(p)
+                    elif d is not None:
+                        decisions.append(d)
+        if progress:
+            progress(f"triage: {len(stage2) - len(stage3)} dropped, {len(stage3)} to full screen")
+
+        # Stage 3 — coder resident for the whole stage.
+        if stage3:
+            with cf.ThreadPoolExecutor(max_workers=gate_workers) as pool:
+                decisions.extend(pool.map(self._gates, stage3))
+
+        return decisions
+
+    # Families the funnel exists to find. Anything else is a drop unless the
+    # model itself is unsure.
+    KEEP_FAMILIES = {"platform", "devops", "build-release",
+                     "developer-experience", "infrastructure"}
+
+    def _triage(self, p: dict) -> tuple[Decision | None, bool]:
+        title = (p.get("title") or "").strip()
+        base = dict(url=p.get("url", ""), title=title, company=p.get("company", ""))
+        try:
+            t = self.llm.json_call(
+                self.triage_model, TRIAGE_SYSTEM,
+                f"Title: {title}\nCompany: {p.get('company','')}", TRIAGE_SCHEMA,
+                max_tokens=400,
+            )
+        except Exception:
+            return None, True  # fail open — a model problem must not shrink the funnel
+
+        # Decide on the CLASSIFICATION, not on the model's `keep` boolean.
+        # Trusting `keep` made triage drop 0 of 33 on a live run — the model
+        # rubber-stamped Developer Advocate, Content Strategist and two AI
+        # Engineer roles straight into the expensive stage. The family label is
+        # a far more reliable signal than a yes/no it has been nudged toward.
+        family, level = t.get("family"), t.get("level")
+
+        if family in self.KEEP_FAMILIES:
+            # Right kind of work — ALWAYS goes to the full screen, whatever the
+            # model says about level. It infers "below-senior" from the mere
+            # absence of a seniority word, which would have dropped a plain
+            # "DevOps Engineer" that scored 85 on a live run. Explicit level
+            # misses (junior/staff/principal/manager) are already caught for
+            # free by rules_stage; anything subtler needs the JD, not the title.
+            return None, True
+
+        if family == "sre":
+            # Excluded family, but "SRE" in a title often means platform work.
+            # Let the full screen read the JD and gate on quoted evidence.
+            return None, True
+
+        return Decision(**base, keep=False, stage="triage",
+                        reason=f"{family}/{level}: {t.get('reason','')}",
+                        detail=t), False
+
+    def _gates(self, p: dict) -> Decision:
+        title = (p.get("title") or "").strip()
+        base = dict(url=p.get("url", ""), title=title, company=p.get("company", ""))
+        jd = (p.get("description") or "").strip()
+        try:
+            g = self.llm.json_call(
+                self.screen_model, self.gate_system,
+                f"COMPANY: {p.get('company','')}\nTITLE: {title}\n\nPOSTING:\n{jd[:self.max_jd_chars]}",
+                GATE_SCHEMA, max_tokens=1600,
+            )
+        except Exception as err:
+            # Catch broadly and on purpose. Anything escaping here kills the
+            # ThreadPoolExecutor.map and takes the whole night's work with it —
+            # which is how one ConnectionResetError lost a 20-minute run.
+            # A failed screen is a kept posting, never a crash.
+            return Decision(**base, keep=True, stage="gates",
+                            reason=f"screen failed, passing through: "
+                                   f"{type(err).__name__}: {err}")
+
+        gates = [x for x in g.get("gate_failures", []) if x.get("evidence", "").strip()]
+        fit = int(g.get("fit_sketch") or 0)
+        if gates:
+            return Decision(**base, keep=False, stage="gates",
+                            reason=f"gate: {gates[0].get('gate')}", detail=g)
+        if not g.get("worth_paid_scoring") and fit < self.fit_floor:
+            return Decision(**base, keep=False, stage="gates",
+                            reason=f"not worth scoring (fit sketch {fit})", detail=g)
+        return Decision(**base, keep=True, stage="kept", reason=f"fit sketch {fit}", detail=g)
+
+    def screen(self, posting: dict) -> Decision:
+        url = posting.get("url", "")
+        title = (posting.get("title") or "").strip()
+        company = posting.get("company", "")
+        jd = (posting.get("description") or "").strip()
+
+        base = dict(url=url, title=title, company=company)
+
+        ok, why = rules_stage(title)
+        if not ok:
+            return Decision(**base, keep=False, stage="rules", reason=why)
+
+        if not jd:
+            return Decision(**base, keep=False, stage="rules", reason="empty description")
+
+        # Stage 2 — title triage on the small GPU-resident model.
+        try:
+            t = self.llm.json_call(
+                self.triage_model, TRIAGE_SYSTEM,
+                f"Title: {title}\nCompany: {company}", TRIAGE_SCHEMA,
+                max_tokens=400,
+            )
+        except LLMError as err:
+            # Fail open: a model problem must not silently shrink the funnel.
+            return Decision(**base, keep=True, stage="triage",
+                            reason=f"triage failed, passing through: {err}")
+
+        if not t.get("keep"):
+            if t.get("level") == "unclear" or _SENIOR_HINT.search(title):
+                pass  # ambiguity is not a rejection
+            else:
+                return Decision(
+                    **base, keep=False, stage="triage",
+                    reason=f"{t.get('family')}/{t.get('level')}: {t.get('reason','')}",
+                    detail=t,
+                )
+
+        # Stage 3 — full screen on the MoE scorer.
+        try:
+            g = self.llm.json_call(
+                self.screen_model, self.gate_system,
+                f"COMPANY: {company}\nTITLE: {title}\n\nPOSTING:\n{jd[:self.max_jd_chars]}",
+                GATE_SCHEMA, max_tokens=1600,
+            )
+        except Exception as err:
+            # Catch broadly and on purpose. Anything escaping here kills the
+            # ThreadPoolExecutor.map and takes the whole night's work with it —
+            # which is how one ConnectionResetError lost a 20-minute run.
+            # A failed screen is a kept posting, never a crash.
+            return Decision(**base, keep=True, stage="gates",
+                            reason=f"screen failed, passing through: "
+                                   f"{type(err).__name__}: {err}")
+
+        gates = [x for x in g.get("gate_failures", []) if x.get("evidence", "").strip()]
+        fit = int(g.get("fit_sketch") or 0)
+
+        if gates:
+            return Decision(**base, keep=False, stage="gates",
+                            reason=f"gate: {gates[0].get('gate')}", detail=g)
+        if not g.get("worth_paid_scoring") and fit < self.fit_floor:
+            return Decision(**base, keep=False, stage="gates",
+                            reason=f"not worth scoring (fit sketch {fit})", detail=g)
+
+        return Decision(**base, keep=True, stage="kept",
+                        reason=f"fit sketch {fit}", detail=g)

--- a/job-board/overnight/prescreen.py
+++ b/job-board/overnight/prescreen.py
@@ -184,9 +184,10 @@ class Prescreener:
         self.llm = llm
         self.triage_model = triage_model
         self.screen_model = screen_model
-        self.extra_drops = build_title_drops(
-            title_drops_extra if title_drops_extra is not None
-            else os.environ.get("TITLE_DROPS_EXTRA"))
+        # The CLI (discover.py) resolves $TITLE_DROPS_EXTRA into the flag;
+        # reading env here too would make direct construction (tests, library
+        # use) inherit ambient state from the operator's shell.
+        self.extra_drops = build_title_drops(title_drops_extra)
         self.fit_floor = fit_floor
         self.max_jd_chars = max_jd_chars
         self.gate_system = GATE_SYSTEM_TMPL.format(

--- a/job-board/overnight/prescreen.py
+++ b/job-board/overnight/prescreen.py
@@ -34,6 +34,7 @@ substitute for the authoritative score.
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass, field
 
@@ -134,25 +135,36 @@ class Decision:
 
 
 # Stage 1 — deterministic. Cheapest possible rejection.
-_HARD_TITLE_DROPS = re.compile(
-    r"\b(intern|internship|junior|jr\.?|associate|apprentice|"
-    r"manager|director|head of|vp\b|vice president|chief|"
-    r"principal|staff|distinguished|fellow|"
-    r"recruiter|sales|marketing|designer|"
-    r"front[- ]?end|mobile|ios|android|"
-    r"data scientist|machine learning engineer)\b",
-    re.I,
-)
+# Only universally-safe drops by default: clearly-entry-level markers no
+# operator of THIS funnel is hunting for. Everything that encodes one
+# person's target band or excluded families (staff/principal, manager,
+# frontend, ML, ...) belongs in the operator's private config: cheap ones in
+# TITLE_DROPS_EXTRA / --title-drops-extra, judgment calls in the gates file.
+# An earlier version hardcoded one operator's whole exclusion list here —
+# the privacy failure mode, one layer up.
+_GENERIC_TITLE_DROPS = re.compile(
+    r"\b(intern|internship|apprentice|new[- ]grad)\b", re.I)
 _SENIOR_HINT = re.compile(r"\b(senior|sr\.?|lead)\b", re.I)
 
 
-def rules_stage(title: str) -> tuple[bool, str]:
+def build_title_drops(extra: str | None) -> re.Pattern | None:
+    """Compile TITLE_DROPS_EXTRA / --title-drops-extra: comma-separated
+    words/phrases, matched case-insensitively on word boundaries."""
+    terms = [t.strip() for t in (extra or "").split(",") if t.strip()]
+    if not terms:
+        return None
+    return re.compile(
+        r"\b(" + "|".join(re.escape(t) for t in terms) + r")\b", re.I)
+
+
+def rules_stage(title: str, extra_drops: re.Pattern | None = None) -> tuple[bool, str]:
     t = (title or "").strip()
     if not t:
         return False, "no title"
-    m = _HARD_TITLE_DROPS.search(t)
-    if m:
-        return False, f"title contains {m.group(0)!r}"
+    for pat in (_GENERIC_TITLE_DROPS, extra_drops):
+        m = pat.search(t) if pat else None
+        if m:
+            return False, f"title contains {m.group(0)!r}"
     return True, ""
 
 
@@ -165,12 +177,16 @@ class Prescreener:
         resume_text: str,
         triage_model: str = "scorer",
         screen_model: str = "coder",
+        title_drops_extra: str | None = None,
         fit_floor: int = 25,
         max_jd_chars: int = 24000,
     ):
         self.llm = llm
         self.triage_model = triage_model
         self.screen_model = screen_model
+        self.extra_drops = build_title_drops(
+            title_drops_extra if title_drops_extra is not None
+            else os.environ.get("TITLE_DROPS_EXTRA"))
         self.fit_floor = fit_floor
         self.max_jd_chars = max_jd_chars
         self.gate_system = GATE_SYSTEM_TMPL.format(
@@ -201,7 +217,7 @@ class Prescreener:
         for p in postings:
             title = (p.get("title") or "").strip()
             base = dict(url=p.get("url", ""), title=title, company=p.get("company", ""))
-            ok, why = rules_stage(title)
+            ok, why = rules_stage(title, self.extra_drops)
             if not ok:
                 decisions.append(Decision(**base, keep=False, stage="rules", reason=why))
             elif not (p.get("description") or "").strip():
@@ -290,7 +306,7 @@ class Prescreener:
             # ThreadPoolExecutor.map and takes the whole night's work with it —
             # which is how one ConnectionResetError lost a 20-minute run.
             # A failed screen is a kept posting, never a crash.
-            return Decision(**base, keep=True, stage="gates",
+            return Decision(**base, keep=True, stage="error",
                             reason=f"screen failed, passing through: "
                                    f"{type(err).__name__}: {err}")
 
@@ -312,7 +328,7 @@ class Prescreener:
 
         base = dict(url=url, title=title, company=company)
 
-        ok, why = rules_stage(title)
+        ok, why = rules_stage(title, self.extra_drops)
         if not ok:
             return Decision(**base, keep=False, stage="rules", reason=why)
 
@@ -328,7 +344,7 @@ class Prescreener:
             )
         except LLMError as err:
             # Fail open: a model problem must not silently shrink the funnel.
-            return Decision(**base, keep=True, stage="triage",
+            return Decision(**base, keep=True, stage="error",
                             reason=f"triage failed, passing through: {err}")
 
         if not t.get("keep"):
@@ -353,7 +369,7 @@ class Prescreener:
             # ThreadPoolExecutor.map and takes the whole night's work with it —
             # which is how one ConnectionResetError lost a 20-minute run.
             # A failed screen is a kept posting, never a crash.
-            return Decision(**base, keep=True, stage="gates",
+            return Decision(**base, keep=True, stage="error",
                             reason=f"screen failed, passing through: "
                                    f"{type(err).__name__}: {err}")
 

--- a/job-board/overnight/prescreen.py
+++ b/job-board/overnight/prescreen.py
@@ -38,6 +38,9 @@ import re
 from dataclasses import dataclass, field
 
 from llm import GATE_SCHEMA, TRIAGE_SCHEMA, LlamaSwap, LLMError
+# The backend's scoring floor lives in one place; sources never
+# imports prescreen, so this import creates no cycle.
+from sources import MIN_DESCRIPTION_CHARS as MIN_DESCRIPTION
 
 TRIAGE_SYSTEM = """You CLASSIFY job titles. You do not decide whether to keep them.
 
@@ -148,9 +151,6 @@ _GENERIC_TITLE_DROPS = re.compile(
     r"\b(intern|internship|apprentice|new[- ]grad)\b", re.I)
 _SENIOR_HINT = re.compile(r"\b(senior|sr\.?|lead)\b", re.I)
 
-# The backend's scoring floor, shared across sources and the prescreen so the
-# number lives in one place (sources.MIN_DESCRIPTION_CHARS).
-from sources import MIN_DESCRIPTION_CHARS as MIN_DESCRIPTION
 
 
 def build_title_drops(extra: str | None) -> re.Pattern | None:
@@ -226,6 +226,7 @@ class Prescreener:
         # here without a lock. Gate failures are already visible (stage=error
         # in the report); triage failures were the last silent degradation.
         self._triage_errors: list[str] = []
+        self._stage2_count = 0
 
         # Stage 1 — free.
         for p in postings:
@@ -246,6 +247,7 @@ class Prescreener:
             progress(f"rules: {len(postings) - len(stage2)} dropped, {len(stage2)} to triage")
 
         # Stage 2 — scorer resident for the whole stage.
+        self._stage2_count = len(stage2)
         stage3: list[dict] = []
         if stage2:
             with cf.ThreadPoolExecutor(max_workers=triage_workers) as pool:
@@ -258,10 +260,13 @@ class Prescreener:
         if progress:
             progress(f"triage: {len(stage2) - len(stage3)} dropped, {len(stage3)} to full screen")
         if self._triage_errors and problems is not None:
-            # One deduped line per failing model, not 400 — a dead triage
-            # model must be visible, not spammy.
-            for msg in sorted(set(self._triage_errors)):
-                problems.append(msg)
+            # Deduped BY MESSAGE but keeping the count: 400 identical
+            # "declared dead" failures and one transient reset must not render
+            # the same. The magnitude is the actionable half.
+            from collections import Counter
+            for msg, n in Counter(self._triage_errors).most_common():
+                problems.append(f"{n} of {self._stage2_count} to triage "
+                                f"UNTRIAGED — {msg}")
 
         # Stage 3 — coder resident for the whole stage.
         if stage3:

--- a/job-board/overnight/report.py
+++ b/job-board/overnight/report.py
@@ -44,9 +44,10 @@ def write_reports(outdir: Path, kept, dropped, fetch_errors, *, submitted,
 
     if submitted:
         lines += ["## Scored overnight", "",
-                  "| rank | company | title |", "|---|---|---|"]
-        for s in sorted(submitted, key=lambda x: x.get("rank") or 0, reverse=True):
-            lines.append(f"| {s.get('rank')} | {s['company']} | {s['title']} |")
+                  "| rank | fit | company | title |", "|---|---|---|---|"]
+        for row in sorted(submitted, key=lambda x: x.get("rank") or 0, reverse=True):
+            lines.append(f"| {row.get('rank')} | {row.get('score')} | "
+                         f"{row['company']} | {row['title']} |")
         lines.append("")
 
     if kept:

--- a/job-board/overnight/report.py
+++ b/job-board/overnight/report.py
@@ -84,7 +84,7 @@ def write_reports(outdir: Path, kept, dropped, fetch_errors, *, submitted,
 
     problems = [e for e in fetch_errors if e]
     if problems:
-        lines += ["## Source problems", ""] + [f"- {e}" for e in problems] + [""]
+        lines += ["## Problems", ""] + [f"- {e}" for e in problems] + [""]
 
     lines += [
         "---",

--- a/job-board/overnight/report.py
+++ b/job-board/overnight/report.py
@@ -54,9 +54,13 @@ def write_reports(outdir: Path, kept, dropped, fetch_errors, *, submitted,
         lines += ["## Kept, in local fit order", "",
                   "| fit~ | company | title | link |", "|---|---|---|---|"]
         for d in kept:
+            # stage=error is a fail-open passthrough, not a screened keep — its
+            # blank fit is "the model never ran", not "the model rated it low".
+            # Flag it so the table doesn't read as a verdict.
+            fit = ("NOT SCREENED (model error)" if d.stage == "error"
+                   else d.detail.get("fit_sketch", "—"))
             lines.append(
-                f"| {d.detail.get('fit_sketch','—')} | {d.company} | {d.title} | [link]({d.url}) |"
-            )
+                f"| {fit} | {d.company} | {d.title} | [link]({d.url}) |")
         lines.append("")
 
     # Gate drops are the ones most worth a human eye — a wrong gate silently

--- a/job-board/overnight/report.py
+++ b/job-board/overnight/report.py
@@ -1,0 +1,95 @@
+"""Morning artifacts: a CSV of everything and a short markdown summary.
+
+The rejection log is the point. A funnel you cannot audit is a funnel you cannot
+tune — every drop records which stage killed it and why, so a morning skim
+answers "what did it throw away, and was it right?" That question is what makes
+the fit_floor and the gate wording improvable instead of superstition.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+from collections import Counter
+from pathlib import Path
+
+FIELDS = ["company", "title", "url", "keep", "stage", "reason", "fit_sketch", "gates"]
+
+
+def write_reports(outdir: Path, kept, dropped, fetch_errors, *, submitted,
+                  dry_run: bool, new_companies: Counter | None = None) -> None:
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    csv_path = outdir / f"prescreen-{stamp}.csv"
+    with csv_path.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=FIELDS)
+        w.writeheader()
+        for d in list(kept) + list(dropped):
+            w.writerow(d.row())
+
+    by_stage = Counter(d.stage for d in dropped)
+    md = outdir / f"summary-{stamp}.md"
+    lines = [
+        f"# Overnight prescreen — {stamp}",
+        "",
+        f"- screened: **{len(kept) + len(dropped)}** unseen postings",
+        f"- kept: **{len(kept)}**",
+        f"- dropped: **{len(dropped)}**"
+        + (f" ({', '.join(f'{k} {v}' for k, v in by_stage.most_common())})" if by_stage else ""),
+        f"- submitted for paid scoring: **{len(submitted)}**"
+        + ("  _(dry run — nothing was spent)_" if dry_run else ""),
+        "",
+    ]
+
+    if submitted:
+        lines += ["## Scored overnight", "",
+                  "| rank | company | title |", "|---|---|---|"]
+        for s in sorted(submitted, key=lambda x: x.get("rank") or 0, reverse=True):
+            lines.append(f"| {s.get('rank')} | {s['company']} | {s['title']} |")
+        lines.append("")
+
+    if kept:
+        lines += ["## Kept, in local fit order", "",
+                  "| fit~ | company | title | link |", "|---|---|---|---|"]
+        for d in kept:
+            lines.append(
+                f"| {d.detail.get('fit_sketch','—')} | {d.company} | {d.title} | [link]({d.url}) |"
+            )
+        lines.append("")
+
+    # Gate drops are the ones most worth a human eye — a wrong gate silently
+    # costs a real job, and the quoted evidence is what makes that checkable.
+    gate_drops = [d for d in dropped if d.stage == "gates"]
+    if gate_drops:
+        lines += ["## Dropped on gates — check these for false positives", "",
+                  "| company | title | gate | evidence |", "|---|---|---|---|"]
+        for d in gate_drops[:40]:
+            for g in d.detail.get("gate_failures", [])[:1]:
+                ev = (g.get("evidence", "") or "").replace("|", "\\|")[:160]
+                lines.append(f"| {d.company} | {d.title} | {g.get('gate')} | {ev} |")
+        lines.append("")
+
+    # Companies are never auto-added to the watch list — that stays a human
+    # decision. This is the shortlist to decide from.
+    if new_companies:
+        lines += [
+            "## Companies worth considering for the watch list", "",
+            "_Not added automatically. These produced roles that survived the prescreen._", "",
+            "| company | keeps |", "|---|---|",
+        ]
+        for name, n in new_companies.most_common(25):
+            lines.append(f"| {name} | {n} |")
+        lines.append("")
+
+    problems = [e for e in fetch_errors if e]
+    if problems:
+        lines += ["## Source problems", ""] + [f"- {e}" for e in problems] + [""]
+
+    lines += [
+        "---",
+        "",
+        f"Full log: `{csv_path.name}`. If the LLM host's storage is scratch, "
+        "sync this directory somewhere durable.",
+    ]
+    md.write_text("\n".join(lines))

--- a/job-board/overnight/sources/__init__.py
+++ b/job-board/overnight/sources/__init__.py
@@ -11,6 +11,11 @@ Every source must:
   * identify itself honestly in the User-Agent
   * be cheap enough to run nightly without being a burden on the host
 
+A source's `collect(limit, problems=None)` appends human-readable strings to
+`problems` (when given) for anything that degraded the run without aborting it
+— a dead feed, a truncated pagination — so the morning report shows the funnel
+narrowing instead of hiding it. `discover.py` always passes its errors list.
+
 Posting shape (matches what the job-store adapters emit, so the rest of the
 pipeline does not care where a posting came from):
 
@@ -41,7 +46,12 @@ USER_AGENT = os.environ.get(
 # path has its own politeness (fetch.PoliteFetcher); this covers the raw
 # API/feed fetches the current sources make.
 _MIN_DELAY_S = float(os.environ.get("SOURCE_MIN_DELAY_S", "2.0"))
-_BLOCK_AFTER = 3          # 403/429s from one host before giving up for the night
+# A single 403/429 blocks the host for the night. Today's sources make one (HN
+# search paginates same-host, WWR is one request per feed), so anything higher
+# would never trigger; the counter still generalizes to a future multi-request
+# source. Retrying into a refusal is the exact pattern the Workday scrapers got
+# caught by, so erring trigger-happy is deliberate.
+_BLOCK_AFTER = int(os.environ.get("SOURCE_BLOCK_AFTER", "1"))
 _last_hit: dict[str, float] = {}
 _refusals: dict[str, int] = {}
 _blocked: set[str] = set()

--- a/job-board/overnight/sources/__init__.py
+++ b/job-board/overnight/sources/__init__.py
@@ -36,6 +36,33 @@ USER_AGENT = os.environ.get(
     "DISCOVERY_USER_AGENT",
     "overnight-discovery/0.1 (self-hosted job search agent)")
 
+# Minimum spacing between requests to the SAME host, applied by polite_get.
+# Sources are called serially, so a module-level table is safe. The adapters
+# path has its own politeness (fetch.PoliteFetcher); this covers the raw
+# API/feed fetches the current sources make.
+_MIN_DELAY_S = float(os.environ.get("SOURCE_MIN_DELAY_S", "2.0"))
+_last_hit: dict[str, float] = {}
+
+
+def polite_get(url: str, timeout: int = 30) -> bytes:
+    """GET with an honest UA and a per-host minimum delay. All source fetches
+    go through here so the README's rate-limiting guarantee is made by code,
+    not by prose."""
+    import time
+    import urllib.parse
+    import urllib.request
+    host = urllib.parse.urlparse(url).netloc.lower()
+    last = _last_hit.get(host)
+    if last is not None:
+        wait = _MIN_DELAY_S - (time.monotonic() - last)
+        if wait > 0:
+            time.sleep(wait)
+    _last_hit[host] = time.monotonic()
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
 _TAG = re.compile(r"<[^>]+>")
 _WS = re.compile(r"[ \t\r\f\v]+")
 _BLANKS = re.compile(r"\n{3,}")
@@ -68,4 +95,4 @@ from . import hn, wwr  # noqa: E402
 
 SOURCES = {"hn": hn, "wwr": wwr}
 
-__all__ = ["SOURCES", "USER_AGENT", "posting", "strip_html"]
+__all__ = ["SOURCES", "USER_AGENT", "polite_get", "posting", "strip_html"]

--- a/job-board/overnight/sources/__init__.py
+++ b/job-board/overnight/sources/__init__.py
@@ -41,6 +41,12 @@ USER_AGENT = os.environ.get(
     "DISCOVERY_USER_AGENT",
     "overnight-discovery/0.1 (self-hosted job search agent)")
 
+# job-store scores nothing below this many chars of description (its app.py
+# threshold). One source of truth: sources gate on it at collection, the
+# prescreen enforces it in stage 1, so a sub-floor posting never reaches a
+# paid call from any path.
+MIN_DESCRIPTION_CHARS = 100
+
 # Minimum spacing between requests to the SAME host, applied by polite_get.
 # Sources are called serially, so a module-level table is safe. The adapters
 # path has its own politeness (fetch.PoliteFetcher); this covers the raw
@@ -125,4 +131,4 @@ from . import hn, wwr  # noqa: E402
 
 SOURCES = {"hn": hn, "wwr": wwr}
 
-__all__ = ["SOURCES", "USER_AGENT", "HostBlocked", "polite_get", "posting", "strip_html"]
+__all__ = ["SOURCES", "USER_AGENT", "HostBlocked", "polite_get", "posting", "strip_html", "MIN_DESCRIPTION_CHARS"]

--- a/job-board/overnight/sources/__init__.py
+++ b/job-board/overnight/sources/__init__.py
@@ -41,17 +41,30 @@ USER_AGENT = os.environ.get(
 # path has its own politeness (fetch.PoliteFetcher); this covers the raw
 # API/feed fetches the current sources make.
 _MIN_DELAY_S = float(os.environ.get("SOURCE_MIN_DELAY_S", "2.0"))
+_BLOCK_AFTER = 3          # 403/429s from one host before giving up for the night
 _last_hit: dict[str, float] = {}
+_refusals: dict[str, int] = {}
+_blocked: set[str] = set()
+
+
+class HostBlocked(RuntimeError):
+    """This host has refused us enough times tonight; stop asking."""
 
 
 def polite_get(url: str, timeout: int = 30) -> bytes:
-    """GET with an honest UA and a per-host minimum delay. All source fetches
-    go through here so the README's rate-limiting guarantee is made by code,
-    not by prose."""
+    """GET with an honest UA, a per-host minimum delay, and a per-host
+    circuit breaker on repeated 403/429. All source fetches go through here so
+    the README's politeness guarantees are made by code, not by prose.
+    Retrying into a block turns a one-off refusal into a pattern — the breaker
+    is deliberately trigger-happy, same policy as fetch.PoliteFetcher."""
     import time
+    import urllib.error
     import urllib.parse
     import urllib.request
     host = urllib.parse.urlparse(url).netloc.lower()
+    if host in _blocked:
+        raise HostBlocked(
+            f"{host}: skipped, refused {_refusals.get(host, 0)}x tonight")
     last = _last_hit.get(host)
     if last is not None:
         wait = _MIN_DELAY_S - (time.monotonic() - last)
@@ -59,8 +72,15 @@ def polite_get(url: str, timeout: int = 30) -> bytes:
             time.sleep(wait)
     _last_hit[host] = time.monotonic()
     req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.read()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as err:
+        if err.code in (403, 429):
+            _refusals[host] = _refusals.get(host, 0) + 1
+            if _refusals[host] >= _BLOCK_AFTER:
+                _blocked.add(host)
+        raise
 
 
 _TAG = re.compile(r"<[^>]+>")
@@ -95,4 +115,4 @@ from . import hn, wwr  # noqa: E402
 
 SOURCES = {"hn": hn, "wwr": wwr}
 
-__all__ = ["SOURCES", "USER_AGENT", "polite_get", "posting", "strip_html"]
+__all__ = ["SOURCES", "USER_AGENT", "HostBlocked", "polite_get", "posting", "strip_html"]

--- a/job-board/overnight/sources/__init__.py
+++ b/job-board/overnight/sources/__init__.py
@@ -1,0 +1,71 @@
+"""Discovery sources: where new postings come from.
+
+A source is a callable returning a list of Posting dicts. Sources go OUT and
+find roles at companies the watch list has never heard of — that is the whole
+point of this module. Polling companies already on the watch list is the
+poller's job and is deliberately not duplicated here.
+
+Every source must:
+  * use an official API or feed where one exists, rather than scraping HTML
+  * respect robots.txt and any stated content signals
+  * identify itself honestly in the User-Agent
+  * be cheap enough to run nightly without being a burden on the host
+
+Posting shape (matches what the job-store adapters emit, so the rest of the
+pipeline does not care where a posting came from):
+
+    {url, title, company, description, source, posted_at|None}
+
+Sources deliberately NOT implemented
+------------------------------------
+RemoteOK: robots.txt disallows `/*?action=get_jobs` (the JSON jobs API) for all
+user agents and individually blocks every major AI crawler. Checked 2026-08-02.
+The site has said no; we take it at its word.
+"""
+
+from __future__ import annotations
+
+import html
+import os
+import re
+
+# Identify YOURSELF to the sites you fetch — an honest UA with a contact path
+# is part of being a polite bot. Set it once via env; the default names the
+# toolkit but not you.
+USER_AGENT = os.environ.get(
+    "DISCOVERY_USER_AGENT",
+    "overnight-discovery/0.1 (self-hosted job search agent)")
+
+_TAG = re.compile(r"<[^>]+>")
+_WS = re.compile(r"[ \t\r\f\v]+")
+_BLANKS = re.compile(r"\n{3,}")
+
+
+def strip_html(raw: str | None) -> str:
+    """HTML fragment -> readable text, preserving paragraph breaks."""
+    if not raw:
+        return ""
+    s = re.sub(r"(?i)<br\s*/?>", "\n", raw)
+    s = re.sub(r"(?i)</p\s*>", "\n\n", s)
+    s = _TAG.sub("", s)
+    s = html.unescape(s)
+    s = _WS.sub(" ", s)
+    return _BLANKS.sub("\n\n", s).strip()
+
+
+def posting(url, title, company, description, source, posted_at=None) -> dict:
+    return {
+        "url": url,
+        "title": (title or "").strip(),
+        "company": (company or "").strip(),
+        "description": description or "",
+        "source": source,
+        "posted_at": posted_at,
+    }
+
+
+from . import hn, wwr  # noqa: E402
+
+SOURCES = {"hn": hn, "wwr": wwr}
+
+__all__ = ["SOURCES", "USER_AGENT", "posting", "strip_html"]

--- a/job-board/overnight/sources/hn.py
+++ b/job-board/overnight/sources/hn.py
@@ -1,0 +1,161 @@
+"""Hacker News "Ask HN: Who is hiring?" via the official Algolia API.
+
+Why this source: it is the highest signal-per-request available. One monthly
+thread carries ~400-500 postings, skewed hard toward remote senior infrastructure
+work at companies that do not advertise on job boards. No scraping, no robots
+concerns — hn.algolia.com is a public API meant to be queried.
+
+Two conventions of the thread are load-bearing:
+
+  * Only TOP-LEVEL comments are job postings. Replies are discussion. Algolia
+    exposes `parent_id`, so `parent_id == story_id` is the filter. Without it
+    roughly half of what you collect is people arguing about compensation.
+
+  * The de-facto format is `Company | Role | Location | REMOTE | ...` on the
+    first line, then prose. It is a convention, not a schema — plenty of posts
+    ignore it — so parsing is best-effort and the model does the real work.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+import urllib.request
+
+from . import USER_AGENT, posting, strip_html
+
+ALGOLIA = "https://hn.algolia.com/api/v1"
+_THREAD_RE = re.compile(r"^Ask HN: Who is hiring\?", re.I)
+_URL_RE = re.compile(r'https?://[^\s<>"\')]+')
+
+# Links that are never the job posting itself.
+_SKIP_HOSTS = (
+    "news.ycombinator.com", "twitter.com", "x.com", "linkedin.com",
+    "youtube.com", "github.com/orgs", "calendly.com",
+)
+# Prefer a real ATS link when the comment offers several.
+_ATS_HINTS = (
+    "greenhouse.io", "ashbyhq.com", "lever.co", "myworkdayjobs.com",
+    "taleo.net", "rippling.com", "icims.com", "jobs.", "careers.",
+    "/careers", "/jobs",
+)
+
+
+def _get(url: str, timeout: int = 30):
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def latest_thread() -> dict | None:
+    """Most recent monthly hiring thread. Excludes the freelancer/wants-to-be-hired variants."""
+    q = urllib.parse.quote('"Ask HN: Who is hiring"')
+    data = _get(f"{ALGOLIA}/search_by_date?query={q}&tags=story&hitsPerPage=20")
+    for hit in data.get("hits", []):
+        title = hit.get("title") or ""
+        if _THREAD_RE.match(title) and "freelance" not in title.lower():
+            return hit
+    return None
+
+
+def _best_url(text: str) -> str | None:
+    urls = [u.rstrip(".,);") for u in _URL_RE.findall(text)]
+    urls = [u for u in urls if not any(h in u for h in _SKIP_HOSTS)]
+    if not urls:
+        return None
+    for u in urls:
+        if any(h in u.lower() for h in _ATS_HINTS):
+            return u
+    return urls[0]
+
+
+def _company_and_title(first_line: str) -> tuple[str, str]:
+    """Parse the `Company | Role | Location` convention, tolerantly."""
+    parts = [p.strip() for p in re.split(r"\s*[|•·]\s*|\s+-\s+", first_line) if p.strip()]
+    if not parts:
+        return "", ""
+    company = parts[0]
+    # The role is the next part that looks like a job title rather than a
+    # location or a REMOTE tag.
+    noise = re.compile(
+        r"^(remote|onsite|hybrid|full[- ]?time|part[- ]?time|contract|visa|"
+        r"\$|us|usa|eu|uk|anywhere|worldwide)\b", re.I)
+    title = next((p for p in parts[1:] if not noise.match(p)), "")
+    return company[:80], title[:120]
+
+
+# Not every top-level comment is a job. The thread also collects book
+# recommendations, meta-discussion, and posts whose first line is a location or
+# a salary, which parse into nonsense like title="70k" or title="New York, NY".
+# Sending those to the LLM stages wastes the expensive model on noise.
+_HIRING_HINT = re.compile(
+    r"\b(hiring|we[''`]?re looking|join us|apply|role|position|engineer|"
+    r"developer|opening|full[- ]?time|remote)\b", re.I)
+_NOT_A_TITLE = re.compile(
+    r"^(\$?\d[\d,.kK+\s-]*|remote|onsite|hybrid|anywhere|worldwide|"
+    r"[a-z ]+,\s*[a-z]{2})$", re.I)
+
+
+def _looks_like_posting(company: str, title: str, text: str) -> bool:
+    if len(text) < 80:                      # too short to be a real posting
+        return False
+    if not _HIRING_HINT.search(text):       # reads like discussion, not a job
+        return False
+    if not title or len(title) < 3 or _NOT_A_TITLE.match(title.strip()):
+        return False
+    # A company name that is really a sentence fragment ("This book was one of…")
+    if len(company.split()) > 6:
+        return False
+    return True
+
+
+def collect(limit: int = 500) -> list[dict]:
+    thread = latest_thread()
+    if not thread:
+        return []
+    story_id = thread["objectID"]
+
+    out: list[dict] = []
+    page = 0
+    while len(out) < limit:
+        data = _get(
+            f"{ALGOLIA}/search?tags=comment,story_{story_id}"
+            f"&hitsPerPage=100&page={page}"
+        )
+        hits = data.get("hits", [])
+        if not hits:
+            break
+
+        for h in hits:
+            # Top-level comments only — replies are discussion, not postings.
+            if str(h.get("parent_id")) != str(story_id):
+                continue
+            text = strip_html(h.get("comment_text"))
+            if not text:
+                continue
+            lines = [ln for ln in text.splitlines() if ln.strip()]
+            if not lines:
+                continue
+
+            company, title = _company_and_title(lines[0])
+            url = _best_url(text)
+            if not url or not company:
+                continue
+            if not _looks_like_posting(company, title, text):
+                continue
+
+            out.append(posting(
+                url=url,
+                title=title or lines[0][:120],
+                company=company,
+                description=text,
+                source=f"hn:{thread.get('title', 'who-is-hiring')}",
+                posted_at=(h.get("created_at") or "")[:10] or None,
+            ))
+
+        if page >= data.get("nbPages", 1) - 1:
+            break
+        page += 1
+
+    return out[:limit]

--- a/job-board/overnight/sources/hn.py
+++ b/job-board/overnight/sources/hn.py
@@ -113,9 +113,11 @@ def _looks_like_posting(company: str, title: str, text: str) -> bool:
     return True
 
 
-def collect(limit: int = 500) -> list[dict]:
+def collect(limit: int = 500, problems: list[str] | None = None) -> list[dict]:
     thread = latest_thread()
     if not thread:
+        if problems is not None:
+            problems.append("hn: no 'Who is hiring' thread found this month")
         return []
     story_id = thread["objectID"]
 

--- a/job-board/overnight/sources/hn.py
+++ b/job-board/overnight/sources/hn.py
@@ -22,7 +22,7 @@ import json
 import re
 import urllib.parse
 
-from . import polite_get, posting, strip_html
+from . import MIN_DESCRIPTION_CHARS, polite_get, posting, strip_html
 
 ALGOLIA = "https://hn.algolia.com/api/v1"
 _THREAD_RE = re.compile(r"^Ask HN: Who is hiring\?", re.I)
@@ -94,14 +94,8 @@ _NOT_A_TITLE = re.compile(
     r"[a-z ]+,\s*[a-z]{2})$", re.I)
 
 
-# job-store scores nothing under 100 chars of description (app.py's
-# threshold) — anything shorter would eat a --max-submit slot and upsert
-# unscored, so the floor here matches the backend's.
-_MIN_TEXT = 100
-
-
 def _looks_like_posting(company: str, title: str, text: str) -> bool:
-    if len(text) < _MIN_TEXT:               # too short to be a real posting
+    if len(text) < MIN_DESCRIPTION_CHARS:               # too short to be a real posting
         return False
     if not _HIRING_HINT.search(text):       # reads like discussion, not a job
         return False

--- a/job-board/overnight/sources/hn.py
+++ b/job-board/overnight/sources/hn.py
@@ -124,10 +124,19 @@ def collect(limit: int = 500, problems: list[str] | None = None) -> list[dict]:
     out: list[dict] = []
     page = 0
     while len(out) < limit:
-        data = _get(
-            f"{ALGOLIA}/search?tags=comment,story_{story_id}"
-            f"&hitsPerPage=100&page={page}"
-        )
+        try:
+            data = _get(
+                f"{ALGOLIA}/search?tags=comment,story_{story_id}"
+                f"&hitsPerPage=100&page={page}"
+            )
+        except Exception as err:                        # noqa: BLE001
+            # Keep what earlier pages already yielded — one 500 on page N (or a
+            # HostBlocked from the shared breaker) must not discard a whole
+            # night's HN harvest. Same policy as wwr's per-feed handling.
+            if problems is not None:
+                problems.append(f"hn: pagination stopped at page {page}: "
+                                f"{type(err).__name__}: {err}")
+            break
         hits = data.get("hits", [])
         if not hits:
             break

--- a/job-board/overnight/sources/hn.py
+++ b/job-board/overnight/sources/hn.py
@@ -94,8 +94,14 @@ _NOT_A_TITLE = re.compile(
     r"[a-z ]+,\s*[a-z]{2})$", re.I)
 
 
+# job-store scores nothing under 100 chars of description (app.py's
+# threshold) — anything shorter would eat a --max-submit slot and upsert
+# unscored, so the floor here matches the backend's.
+_MIN_TEXT = 100
+
+
 def _looks_like_posting(company: str, title: str, text: str) -> bool:
-    if len(text) < 80:                      # too short to be a real posting
+    if len(text) < _MIN_TEXT:               # too short to be a real posting
         return False
     if not _HIRING_HINT.search(text):       # reads like discussion, not a job
         return False

--- a/job-board/overnight/sources/hn.py
+++ b/job-board/overnight/sources/hn.py
@@ -21,9 +21,8 @@ from __future__ import annotations
 import json
 import re
 import urllib.parse
-import urllib.request
 
-from . import USER_AGENT, posting, strip_html
+from . import polite_get, posting, strip_html
 
 ALGOLIA = "https://hn.algolia.com/api/v1"
 _THREAD_RE = re.compile(r"^Ask HN: Who is hiring\?", re.I)
@@ -43,9 +42,7 @@ _ATS_HINTS = (
 
 
 def _get(url: str, timeout: int = 30):
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return json.load(resp)
+    return json.loads(polite_get(url, timeout=timeout))
 
 
 def latest_thread() -> dict | None:

--- a/job-board/overnight/sources/wwr.py
+++ b/job-board/overnight/sources/wwr.py
@@ -16,15 +16,9 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 
-from . import polite_get, posting, strip_html
+from . import MIN_DESCRIPTION_CHARS, polite_get, posting, strip_html
 
 BASE = "https://weworkremotely.com/categories"
-
-# Mirror of the backend's scoring floor (prescreen.MIN_DESCRIPTION / job-store
-# app.py). Kept as a local constant rather than importing the prescreener into
-# a source module — if the backend floor changes, both move together by intent,
-# and the test in tests/test_wwr.py pins that a region-padded teaser is dropped.
-MIN_JD_CHARS = 100
 
 # Categories worth reading for infrastructure work. WWR has no
 # platform/infra category, so devops is the primary and programming is the
@@ -77,7 +71,7 @@ def collect(limit: int = 300, feeds: dict[str, str] | None = None,
             # backend's scoring floor (which means "enough JD to be worth
             # paying for"). Measuring here rather than trusting the prescreen's
             # stage-1 length check is what keeps the padding from rescuing it.
-            if len(jd) < MIN_JD_CHARS:
+            if len(jd) < MIN_DESCRIPTION_CHARS:
                 continue
             body = f"Region: {region}\n\n{jd}" if region else jd
 

--- a/job-board/overnight/sources/wwr.py
+++ b/job-board/overnight/sources/wwr.py
@@ -1,0 +1,79 @@
+"""WeWorkRemotely via its official category RSS feeds.
+
+robots.txt checked 2026-08-02: `User-agent: *` / `Allow: /`, with only admin and
+account paths disallowed. The RSS feeds are published for consumption, so we use
+those rather than parsing listing HTML.
+
+Feed titles follow `Company: Role`, and the description carries the full JD as
+an HTML fragment — enough to prescreen without fetching the posting page, which
+keeps us to one request per feed per night.
+
+Note the feeds are noisy: the DevOps/Sysadmin category reliably contains sales
+and support roles. That is expected and is what the rules stage is for.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+import xml.etree.ElementTree as ET
+
+from . import USER_AGENT, posting, strip_html
+
+BASE = "https://weworkremotely.com/categories"
+
+# Categories worth reading for infrastructure work. WWR has no
+# platform/infra category, so devops is the primary and programming is the
+# wider net that occasionally carries platform roles.
+FEEDS = {
+    "devops": f"{BASE}/remote-devops-sysadmin-jobs.rss",
+    "programming": f"{BASE}/remote-programming-jobs.rss",
+}
+
+
+def _fetch(url: str, timeout: int = 45) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def _text(item: ET.Element, tag: str) -> str:
+    el = item.find(tag)
+    return (el.text or "").strip() if el is not None and el.text else ""
+
+
+def collect(limit: int = 300, feeds: dict[str, str] | None = None) -> list[dict]:
+    out: list[dict] = []
+    for name, url in (feeds or FEEDS).items():
+        try:
+            root = ET.fromstring(_fetch(url))
+        except Exception:
+            continue  # a dead feed must not take the whole night down
+
+        for item in root.findall(".//item"):
+            raw_title = _text(item, "title")
+            link = _text(item, "link")
+            if not link:
+                continue
+
+            # "Company: Role" — split on the first colon only.
+            if ":" in raw_title:
+                company, _, title = raw_title.partition(":")
+            else:
+                company, title = "", raw_title
+
+            region = _text(item, "region")
+            body = strip_html(_text(item, "description"))
+            if region:
+                body = f"Region: {region}\n\n{body}"
+
+            out.append(posting(
+                url=link,
+                title=title.strip() or raw_title,
+                company=company.strip(),
+                description=body,
+                source=f"wwr:{name}",
+                posted_at=None,
+            ))
+            if len(out) >= limit:
+                return out
+    return out

--- a/job-board/overnight/sources/wwr.py
+++ b/job-board/overnight/sources/wwr.py
@@ -14,10 +14,9 @@ and support roles. That is expected and is what the rules stage is for.
 
 from __future__ import annotations
 
-import urllib.request
 import xml.etree.ElementTree as ET
 
-from . import USER_AGENT, posting, strip_html
+from . import polite_get, posting, strip_html
 
 BASE = "https://weworkremotely.com/categories"
 
@@ -31,9 +30,7 @@ FEEDS = {
 
 
 def _fetch(url: str, timeout: int = 45) -> bytes:
-    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
-        return resp.read()
+    return polite_get(url, timeout=timeout)
 
 
 def _text(item: ET.Element, tag: str) -> str:

--- a/job-board/overnight/sources/wwr.py
+++ b/job-board/overnight/sources/wwr.py
@@ -38,13 +38,19 @@ def _text(item: ET.Element, tag: str) -> str:
     return (el.text or "").strip() if el is not None and el.text else ""
 
 
-def collect(limit: int = 300, feeds: dict[str, str] | None = None) -> list[dict]:
+def collect(limit: int = 300, feeds: dict[str, str] | None = None,
+            problems: list[str] | None = None) -> list[dict]:
     out: list[dict] = []
     for name, url in (feeds or FEEDS).items():
         try:
             root = ET.fromstring(_fetch(url))
-        except Exception:
-            continue  # a dead feed must not take the whole night down
+        except Exception as err:
+            # A dead feed must not take the whole night down — but it must
+            # not be INVISIBLE either, or the funnel silently narrows to
+            # HN-only. Record it where the morning report will show it.
+            if problems is not None:
+                problems.append(f"wwr feed {name!r}: {type(err).__name__}: {err}")
+            continue
 
         for item in root.findall(".//item"):
             raw_title = _text(item, "title")

--- a/job-board/overnight/sources/wwr.py
+++ b/job-board/overnight/sources/wwr.py
@@ -20,6 +20,12 @@ from . import polite_get, posting, strip_html
 
 BASE = "https://weworkremotely.com/categories"
 
+# Mirror of the backend's scoring floor (prescreen.MIN_DESCRIPTION / job-store
+# app.py). Kept as a local constant rather than importing the prescreener into
+# a source module — if the backend floor changes, both move together by intent,
+# and the test in tests/test_wwr.py pins that a region-padded teaser is dropped.
+MIN_JD_CHARS = 100
+
 # Categories worth reading for infrastructure work. WWR has no
 # platform/infra category, so devops is the primary and programming is the
 # wider net that occasionally carries platform roles.
@@ -65,9 +71,15 @@ def collect(limit: int = 300, feeds: dict[str, str] | None = None,
                 company, title = "", raw_title
 
             region = _text(item, "region")
-            body = strip_html(_text(item, "description"))
-            if region:
-                body = f"Region: {region}\n\n{body}"
+            jd = strip_html(_text(item, "description"))
+            # Drop teasers on the JD ALONE, before the synthesized Region line
+            # is added: 36 chars of metadata must not lift a thin JD over the
+            # backend's scoring floor (which means "enough JD to be worth
+            # paying for"). Measuring here rather than trusting the prescreen's
+            # stage-1 length check is what keeps the padding from rescuing it.
+            if len(jd) < MIN_JD_CHARS:
+                continue
+            body = f"Region: {region}\n\n{jd}" if region else jd
 
             out.append(posting(
                 url=link,

--- a/job-board/overnight/tests/test_discover_seen.py
+++ b/job-board/overnight/tests/test_discover_seen.py
@@ -1,0 +1,32 @@
+"""The seen-set is the spend guardrail: prefer dedupe_keys, fall back to
+computing from urls (older backends), never silently empty on a fallback."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import discover  # noqa: E402
+
+
+class SeenKeysTest(unittest.TestCase):
+    def test_prefers_dedupe_keys(self):
+        got = discover.seen_keys({"dedupe_keys": ["gh:1", "ashby:x"],
+                                  "urls": ["https://example.com/ignored"]})
+        self.assertEqual(got, {"gh:1", "ashby:x"})
+
+    def test_falls_back_to_urls(self):
+        got = discover.seen_keys(
+            {"urls": ["https://boards.greenhouse.io/acme/jobs/123",
+                      "https://jobs.ashbyhq.com/beta/senior-eng"]})
+        self.assertEqual(len(got), 2)
+        self.assertTrue(any(k.startswith("gh:") for k in got))
+
+    def test_empty_payload_is_empty_not_crash(self):
+        self.assertEqual(discover.seen_keys({}), set())
+        self.assertEqual(discover.seen_keys({"dedupe_keys": None, "urls": None}), set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/job-board/overnight/tests/test_hn_parse.py
+++ b/job-board/overnight/tests/test_hn_parse.py
@@ -1,0 +1,59 @@
+"""The HN parse heuristics — the most brittle code here. Synthetic comments."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sources import hn  # noqa: E402
+
+POSTING_TEXT = ("Acme | Senior DevOps Engineer | REMOTE (US) | $150k-$180k\n"
+                "We're hiring a senior engineer to own our deploy pipeline. "
+                "Apply at https://boards.greenhouse.io/acme/jobs/123 or see "
+                "https://news.ycombinator.com/item?id=1 for discussion.")
+
+
+class CompanyTitleTest(unittest.TestCase):
+    def test_convention_parse(self):
+        c, t = hn._company_and_title("Acme | Senior DevOps Engineer | REMOTE | $150k")
+        self.assertEqual((c, t), ("Acme", "Senior DevOps Engineer"))
+
+    def test_noise_parts_skipped_for_title(self):
+        c, t = hn._company_and_title("Acme | REMOTE (US) | Senior Platform Engineer")
+        self.assertEqual(t, "Senior Platform Engineer")
+
+    def test_empty(self):
+        self.assertEqual(hn._company_and_title(""), ("", ""))
+
+
+class LooksLikePostingTest(unittest.TestCase):
+    def test_real_posting_passes(self):
+        self.assertTrue(hn._looks_like_posting("Acme", "Senior DevOps Engineer",
+                                               POSTING_TEXT))
+
+    def test_salary_as_title_rejected(self):
+        self.assertFalse(hn._looks_like_posting("Acme", "70k", POSTING_TEXT))
+
+    def test_location_as_title_rejected(self):
+        self.assertFalse(hn._looks_like_posting("Acme", "New York, NY", POSTING_TEXT))
+
+    def test_short_text_rejected(self):
+        self.assertFalse(hn._looks_like_posting("Acme", "Engineer", "too short"))
+
+    def test_sentence_fragment_company_rejected(self):
+        self.assertFalse(hn._looks_like_posting(
+            "This book was one of the best I", "Engineer", POSTING_TEXT))
+
+
+class BestUrlTest(unittest.TestCase):
+    def test_prefers_ats_link_and_skips_hn(self):
+        self.assertEqual(hn._best_url(POSTING_TEXT),
+                         "https://boards.greenhouse.io/acme/jobs/123")
+
+    def test_no_usable_url(self):
+        self.assertIsNone(hn._best_url("see https://news.ycombinator.com/item?id=1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/job-board/overnight/tests/test_llm.py
+++ b/job-board/overnight/tests/test_llm.py
@@ -1,0 +1,52 @@
+"""LlamaSwap's model circuit breaker, incl. the connect-phase timeout that
+URLError-wraps a socket timeout (PR #76 round-6 finding)."""
+
+import os
+import socket
+import sys
+import unittest
+import urllib.error
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import llm  # noqa: E402
+
+
+class TimeoutPredicateTest(unittest.TestCase):
+    def test_direct_and_wrapped_timeouts(self):
+        self.assertTrue(llm._is_timeout(TimeoutError("read")))
+        self.assertTrue(llm._is_timeout(socket.timeout("read")))
+        # Connect-phase: urllib wraps socket.timeout in URLError.
+        self.assertTrue(llm._is_timeout(urllib.error.URLError(socket.timeout())))
+        self.assertFalse(llm._is_timeout(urllib.error.URLError("dns")))
+        self.assertFalse(llm._is_timeout(ValueError("nope")))
+
+
+class BreakerTest(unittest.TestCase):
+    def _hang(self, exc):
+        def _raise(req, timeout=0):
+            raise exc
+        return _raise
+
+    def test_connect_timeout_trips_breaker_and_fails_fast(self):
+        c = llm.LlamaSwap("http://x", dead_after=2)
+        wrapped = urllib.error.URLError(socket.timeout("connect"))
+        with mock.patch("urllib.request.urlopen", self._hang(wrapped)), \
+             mock.patch("time.sleep", lambda s: None):
+            # First call: retries exhaust, breaker trips at the 2nd timeout.
+            with self.assertRaises(llm.LLMError):
+                c.json_call("coder", "s", "u", {}, retries=2)
+            self.assertIn("coder", c._dead)
+            # Second call: fails fast, no request attempted.
+            calls = []
+            with mock.patch("urllib.request.urlopen",
+                            lambda *a, **k: calls.append(1)):
+                with self.assertRaises(llm.LLMError) as ctx:
+                    c.json_call("coder", "s", "u", {})
+            self.assertIn("declared dead", str(ctx.exception))
+            self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/job-board/overnight/tests/test_polite_get.py
+++ b/job-board/overnight/tests/test_polite_get.py
@@ -39,14 +39,17 @@ class PoliteGetTest(unittest.TestCase):
 
         with mock.patch("time.monotonic", fake_monotonic), \
              mock.patch("time.sleep", fake_sleep), \
-             mock.patch("urllib.request.urlopen", fake_urlopen):
+             mock.patch("urllib.request.urlopen", fake_urlopen), \
+             mock.patch.object(sources, "_MIN_DELAY_S", 2.0):
+            # _MIN_DELAY_S is pinned: it's env-derived at import, and this
+            # test must not inherit the operator's $SOURCE_MIN_DELAY_S.
             sources._last_hit.clear()
             sources.polite_get("https://a.example/one")
             self.assertEqual(sleeps, [])            # first hit: no wait
             clock["now"] += 0.5                     # 0.5s later, same host
             sources.polite_get("https://a.example/two")
             self.assertEqual(len(sleeps), 1)        # had to wait
-            self.assertAlmostEqual(sleeps[0], sources._MIN_DELAY_S - 0.5, places=3)
+            self.assertAlmostEqual(sleeps[0], 1.5, places=3)
             sources.polite_get("https://b.example/other")
             self.assertEqual(len(sleeps), 1)        # new host: no wait
         self.assertEqual(len(fetched), 3)
@@ -70,6 +73,40 @@ class PoliteGetTest(unittest.TestCase):
             sources._last_hit.clear()
             sources.polite_get("https://c.example/x")
         self.assertEqual(seen["ua"], sources.USER_AGENT)
+
+
+class CircuitBreakerTest(unittest.TestCase):
+    def test_repeated_403_blocks_host_for_the_night(self):
+        import urllib.error
+
+        def deny(req, timeout=0):
+            raise urllib.error.HTTPError(req.full_url, 403, "no", {}, None)
+
+        with mock.patch("urllib.request.urlopen", deny), \
+             mock.patch("time.sleep", lambda s: None), \
+             mock.patch.object(sources, "_MIN_DELAY_S", 0.0):
+            sources._last_hit.clear()
+            sources._refusals.clear()
+            sources._blocked.clear()
+            for _ in range(sources._BLOCK_AFTER):
+                with self.assertRaises(urllib.error.HTTPError):
+                    sources.polite_get("https://denied.example/x")
+            with self.assertRaises(sources.HostBlocked):
+                sources.polite_get("https://denied.example/x")
+        sources._refusals.clear()
+        sources._blocked.clear()
+
+
+class WwrFeedVisibilityTest(unittest.TestCase):
+    def test_dead_feed_lands_in_problems(self):
+        from sources import wwr
+        problems = []
+        with mock.patch.object(wwr, "_fetch",
+                               side_effect=RuntimeError("connection refused")):
+            out = wwr.collect(problems=problems)
+        self.assertEqual(out, [])
+        self.assertEqual(len(problems), len(wwr.FEEDS))
+        self.assertIn("wwr feed", problems[0])
 
 
 if __name__ == "__main__":

--- a/job-board/overnight/tests/test_polite_get.py
+++ b/job-board/overnight/tests/test_polite_get.py
@@ -1,0 +1,76 @@
+"""polite_get's per-host delay bookkeeping, with a fake clock — no sleeping,
+no network."""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import sources  # noqa: E402
+
+
+class PoliteGetTest(unittest.TestCase):
+    def test_same_host_waits_and_different_host_does_not(self):
+        clock = {"now": 1000.0}
+        sleeps = []
+
+        def fake_monotonic():
+            return clock["now"]
+
+        def fake_sleep(s):
+            sleeps.append(s)
+            clock["now"] += s
+
+        fetched = []
+
+        class _Resp:
+            def read(self):
+                return b"ok"
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=0):
+            fetched.append(req.full_url)
+            return _Resp()
+
+        with mock.patch("time.monotonic", fake_monotonic), \
+             mock.patch("time.sleep", fake_sleep), \
+             mock.patch("urllib.request.urlopen", fake_urlopen):
+            sources._last_hit.clear()
+            sources.polite_get("https://a.example/one")
+            self.assertEqual(sleeps, [])            # first hit: no wait
+            clock["now"] += 0.5                     # 0.5s later, same host
+            sources.polite_get("https://a.example/two")
+            self.assertEqual(len(sleeps), 1)        # had to wait
+            self.assertAlmostEqual(sleeps[0], sources._MIN_DELAY_S - 0.5, places=3)
+            sources.polite_get("https://b.example/other")
+            self.assertEqual(len(sleeps), 1)        # new host: no wait
+        self.assertEqual(len(fetched), 3)
+
+    def test_sends_the_configured_user_agent(self):
+        seen = {}
+
+        class _Resp:
+            def read(self):
+                return b"ok"
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(req, timeout=0):
+            seen["ua"] = req.get_header("User-agent")
+            return _Resp()
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            sources._last_hit.clear()
+            sources.polite_get("https://c.example/x")
+        self.assertEqual(seen["ua"], sources.USER_AGENT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/job-board/overnight/tests/test_prescreen.py
+++ b/job-board/overnight/tests/test_prescreen.py
@@ -1,0 +1,84 @@
+"""Funnel behavior against a stubbed LLM: triage decides on family (not the
+model's keep boolean), model failures pass through as stage='error' (report,
+never paid submission), and title drops are generic-by-default."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import prescreen  # noqa: E402
+
+
+def _posting(title, company="Acme", desc="x" * 200):
+    return {"url": f"https://example.com/{title}", "title": title,
+            "company": company, "description": desc}
+
+
+class _StubLLM:
+    """json_call stub keyed by model alias; triage='scorer', gates='coder'."""
+
+    def __init__(self, triage=None, gates=None, raise_for=()):
+        self.triage = triage or {}
+        self.gates = gates or {}
+        self.raise_for = raise_for
+
+    def json_call(self, model, system, user, schema, max_tokens=0):
+        if model in self.raise_for:
+            raise prescreen.LLMError(f"{model}: boom")
+        return dict(self.triage if model == "scorer" else self.gates)
+
+
+class RulesStageTest(unittest.TestCase):
+    def test_generic_default_drops_entry_level_only(self):
+        self.assertFalse(prescreen.rules_stage("Platform Engineering Intern")[0])
+        self.assertFalse(prescreen.rules_stage("New Grad SWE")[0])
+        # One operator's band/family exclusions are NOT baked in:
+        for t in ("Staff Software Engineer", "Engineering Manager",
+                  "Frontend Developer", "Principal SRE"):
+            self.assertTrue(prescreen.rules_stage(t)[0], t)
+
+    def test_extra_drops_pattern(self):
+        extra = prescreen.build_title_drops("staff, principal, head of")
+        self.assertFalse(prescreen.rules_stage("Staff Engineer", extra)[0])
+        self.assertFalse(prescreen.rules_stage("Head of Platform", extra)[0])
+        self.assertTrue(prescreen.rules_stage("Senior DevOps Engineer", extra)[0])
+        self.assertIsNone(prescreen.build_title_drops(""))
+
+
+class FunnelTest(unittest.TestCase):
+    def _screen(self, llm, postings):
+        p = prescreen.Prescreener(llm, gates_text="- no gates", resume_text="r",
+                                  title_drops_extra=None)
+        return p.screen_batch(postings, triage_workers=1, gate_workers=1,
+                              progress=lambda m: None)
+
+    def test_triage_decides_on_family_not_keep(self):
+        # Model says keep=True but the family is out — code must drop it.
+        llm = _StubLLM(triage={"keep": True, "family": "devrel",
+                               "level": "senior", "reason": "sounds fun"})
+        (d,) = self._screen(llm, [_posting("Developer Advocate")])
+        self.assertFalse(d.keep)
+        self.assertEqual(d.stage, "triage")
+
+    def test_keeper_family_reaches_gates_and_keeps(self):
+        llm = _StubLLM(
+            triage={"keep": False, "family": "devops", "level": "unclear"},
+            gates={"gate_failures": [], "fit_sketch": 88,
+                   "worth_paid_scoring": True})
+        (d,) = self._screen(llm, [_posting("DevOps Engineer")])
+        self.assertTrue(d.keep)
+        self.assertEqual(d.stage, "kept")
+
+    def test_gate_model_failure_is_error_stage_not_crash(self):
+        llm = _StubLLM(
+            triage={"keep": True, "family": "platform", "level": "senior"},
+            raise_for=("coder",))
+        (d,) = self._screen(llm, [_posting("Platform Engineer")])
+        self.assertTrue(d.keep)                    # fail open into the report
+        self.assertEqual(d.stage, "error")         # but never the paid queue
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/job-board/overnight/tests/test_prescreen.py
+++ b/job-board/overnight/tests/test_prescreen.py
@@ -47,6 +47,17 @@ class RulesStageTest(unittest.TestCase):
         self.assertIsNone(prescreen.build_title_drops(""))
 
 
+class MinDescriptionTest(unittest.TestCase):
+    def test_short_description_dropped_at_rules_for_any_source(self):
+        llm = _StubLLM()   # never consulted — must drop before any model call
+        p = prescreen.Prescreener(llm, gates_text="-", resume_text="r")
+        (d,) = p.screen_batch([_posting("DevOps Engineer", desc="too short")],
+                              triage_workers=1, gate_workers=1,
+                              progress=lambda m: None)
+        self.assertFalse(d.keep)
+        self.assertEqual(d.stage, "rules")
+
+
 class FunnelTest(unittest.TestCase):
     def _screen(self, llm, postings):
         p = prescreen.Prescreener(llm, gates_text="- no gates", resume_text="r",

--- a/job-board/overnight/tests/test_prescreen.py
+++ b/job-board/overnight/tests/test_prescreen.py
@@ -58,6 +58,22 @@ class MinDescriptionTest(unittest.TestCase):
         self.assertEqual(d.stage, "rules")
 
 
+class TriageVisibilityTest(unittest.TestCase):
+    def test_dead_triage_model_reports_count_not_just_presence(self):
+        # A dead triage model must surface in problems WITH its magnitude
+        # (PR #76 round-7: dedupe kept presence but lost the count).
+        llm = _StubLLM(gates={"gate_failures": [], "fit_sketch": 70,
+                              "worth_paid_scoring": True}, raise_for=("scorer",))
+        p = prescreen.Prescreener(llm, gates_text="-", resume_text="r")
+        problems = []
+        p.screen_batch([_posting(f"DevOps Engineer {i}") for i in range(5)],
+                       triage_workers=1, gate_workers=1,
+                       progress=lambda m: None, problems=problems)
+        self.assertEqual(len(problems), 1)          # one deduped line...
+        self.assertIn("5 of 5", problems[0])        # ...but the count survives
+        self.assertIn("UNTRIAGED", problems[0])
+
+
 class FunnelTest(unittest.TestCase):
     def _screen(self, llm, postings):
         p = prescreen.Prescreener(llm, gates_text="- no gates", resume_text="r",

--- a/job-board/overnight/tests/test_report.py
+++ b/job-board/overnight/tests/test_report.py
@@ -30,7 +30,7 @@ class WriteReportsTest(unittest.TestCase):
                              submitted=submitted, dry_run=False)
         md = next(outdir.glob("*.md")).read_text()
         self.assertIn("## Scored overnight", md)
-        self.assertIn("| 84.5 | Acme | DevOps Engineer |", md)
+        self.assertIn("| 84.5 | 88.0 | Acme | DevOps Engineer |", md)
         self.assertNotIn("| None |", md)     # the exact symptom of key drift
 
     def test_problems_section_and_rejection_log(self):

--- a/job-board/overnight/tests/test_report.py
+++ b/job-board/overnight/tests/test_report.py
@@ -1,0 +1,51 @@
+"""write_reports against fixtures — the renderer is where a drifted
+/jobs/score contract goes unnoticed (PR #76 round-2 finding: rank=None in
+every row of the scored table)."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import report  # noqa: E402
+from prescreen import Decision  # noqa: E402
+
+
+class WriteReportsTest(unittest.TestCase):
+    def _decision(self, **kw):
+        base = dict(url="https://example.com/j", title="DevOps Engineer",
+                    company="Acme", keep=True, stage="kept",
+                    reason="fit sketch 90", detail={"fit_sketch": 90})
+        base.update(kw)
+        return Decision(**base)
+
+    def test_scored_table_renders_real_ranks(self):
+        outdir = Path(tempfile.mkdtemp())
+        submitted = [{"url": "https://example.com/j", "title": "DevOps Engineer",
+                      "company": "Acme", "rank": 84.5, "score": 88.0}]
+        report.write_reports(outdir, [self._decision()], [], [],
+                             submitted=submitted, dry_run=False)
+        md = next(outdir.glob("*.md")).read_text()
+        self.assertIn("## Scored overnight", md)
+        self.assertIn("| 84.5 | Acme | DevOps Engineer |", md)
+        self.assertNotIn("| None |", md)     # the exact symptom of key drift
+
+    def test_problems_section_and_rejection_log(self):
+        outdir = Path(tempfile.mkdtemp())
+        dropped = [self._decision(keep=False, stage="gates",
+                                  reason="gate: location", detail={})]
+        report.write_reports(outdir, [], dropped,
+                             ["seen-set is EMPTY — dedupe may be broken"],
+                             submitted=[], dry_run=True)
+        md = next(outdir.glob("*.md")).read_text()
+        self.assertIn("## Problems", md)
+        self.assertIn("seen-set is EMPTY", md)
+        csv = next(outdir.glob("*.csv")).read_text()
+        self.assertIn("gate: location", csv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/job-board/overnight/tests/test_wwr.py
+++ b/job-board/overnight/tests/test_wwr.py
@@ -1,0 +1,47 @@
+"""WWR feed parsing: the Region prefix must not rescue a thin JD past the
+scoring floor (PR #76 round-5 finding — this path spends money)."""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from sources import wwr  # noqa: E402
+
+
+def _feed(items):
+    body = "".join(
+        f"<item><title>{t}</title><link>{l}</link>"
+        f"<region>{r}</region><description>{d}</description></item>"
+        for t, l, r, d in items)
+    return f"<rss><channel>{body}</channel></rss>".encode()
+
+
+class RegionFloorTest(unittest.TestCase):
+    def _collect(self, items):
+        with mock.patch.object(wwr, "_fetch", return_value=_feed(items)):
+            return wwr.collect(feeds={"devops": "x"})
+
+    def test_region_padding_does_not_rescue_a_teaser(self):
+        # 70-char JD + a long region would clear 100 chars combined, but the
+        # JD alone is under the floor -> dropped.
+        teaser = "We are hiring a devops engineer to help us out. Apply soon!"  # ~59
+        self.assertLess(len(teaser), wwr.MIN_JD_CHARS)
+        out = self._collect([("Acme: DevOps Engineer",
+                              "https://example.com/j",
+                              "United States (long region string here)", teaser)])
+        self.assertEqual(out, [])
+
+    def test_real_jd_survives_and_region_is_included(self):
+        jd = "x" * 200
+        out = self._collect([("Acme: DevOps Engineer",
+                              "https://example.com/j", "Europe", jd)])
+        self.assertEqual(len(out), 1)
+        self.assertIn("Region: Europe", out[0]["description"])
+        self.assertIn(jd, out[0]["description"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/job-board/overnight/tests/test_wwr.py
+++ b/job-board/overnight/tests/test_wwr.py
@@ -28,7 +28,7 @@ class RegionFloorTest(unittest.TestCase):
         # 70-char JD + a long region would clear 100 chars combined, but the
         # JD alone is under the floor -> dropped.
         teaser = "We are hiring a devops engineer to help us out. Apply soon!"  # ~59
-        self.assertLess(len(teaser), wwr.MIN_JD_CHARS)
+        self.assertLess(len(teaser), wwr.MIN_DESCRIPTION_CHARS)
         out = self._collect([("Acme: DevOps Engineer",
                               "https://example.com/j",
                               "United States (long region string here)", teaser)])


### PR DESCRIPTION
Adds the overnight discovery agent: finds roles at companies the watch list has never heard of, prescreens them for free on a self-hosted LLM, and submits only survivors for paid authoritative scoring.

```
sources (HN, WWR) -> dedupe vs job-store seen-set -> local prescreen (free)
   -> POST survivors to /jobs/score (paid, capped) -> CSV + morning report
```

## Design decisions
- **Not a poller.** `poller.py` owns the watch list; this widens the funnel beyond it, and roles from watched companies are skipped on sight. Companies are never auto-added — discovered positions go to the board; a human decides who's worth watching.
- **Official APIs/feeds only** (HN Algolia, WWR category RSS), honest env-configurable User-Agent, per-host rate limiting, and a circuit breaker that drops a host for the night on repeated 403/429. RemoteOK is deliberately absent — its robots.txt disallows the jobs API for all agents.
- **Three-stage funnel, cheapest first:** regex rules → small GPU-resident triage model → gates+fit on the big model. Triage classifies (family/level); the *code* applies policy — trusting the model's keep boolean rubber-stamped everything. The prescreen fails open: a model error keeps the posting and records the error.
- **Spend discipline:** dry-run by default; `--submit` gates paid calls, `--max-submit` caps them (25); `force` is never sent; the seen-set is fetched first and every known dedupe key skipped. Local prescreen scores are never written to job-store — the server's single Anthropic call stays authoritative.
- **The rejection log is the product:** every drop records which stage killed it and why, so "what did it throw away, and was it right?" is answerable each morning.

## Local-LLM findings baked in (documented in the README)
Grammar-constrained JSON requires thinking disabled or content comes back empty; scoring rubrics must live in the system prompt (schema descriptions scored 0 on everything); JSON schema property order is load-bearing (evidence before score); screening batches by stage because the LLM host holds one model at a time.

## Privacy
No operator specifics anywhere: endpoints, models, and UA are env/flag-supplied; the gates file (personal deal-breakers) is operator-owned via `--gates`/`$GATES_PATH` and never committed — `gates.example.txt` is a clearly-synthetic template. Stdlib only, per repo convention.

## Testing status
No unit tests yet — validated by live dry runs (latest: 48 screened → 8 kept, 40 dropped with recorded reasons) and zero paid API calls made to date. Test scaffolding is a known follow-up; flagging it here rather than pretending otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)